### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkBinaryThresholdFeatureGenerator.h
+++ b/include/itkBinaryThresholdFeatureGenerator.h
@@ -41,6 +41,8 @@ template <unsigned int NDimension>
 class BinaryThresholdFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryThresholdFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = BinaryThresholdFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -78,9 +80,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  BinaryThresholdFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using OutputPixelType = float;
   using OutputImageType = Image< OutputPixelType, Dimension >;
 

--- a/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
@@ -67,6 +67,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT CannyEdgesDistanceAdvectionFieldFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceAdvectionFieldFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = CannyEdgesDistanceAdvectionFieldFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -116,9 +118,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  CannyEdgesDistanceAdvectionFieldFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkCannyEdgesDistanceFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceFeatureGenerator.h
@@ -62,6 +62,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT CannyEdgesDistanceFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = CannyEdgesDistanceFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -121,9 +123,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  CannyEdgesDistanceFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkCannyEdgesFeatureGenerator.h
+++ b/include/itkCannyEdgesFeatureGenerator.h
@@ -60,6 +60,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT CannyEdgesFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = CannyEdgesFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -119,9 +121,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  CannyEdgesFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkConfidenceConnectedSegmentationModule.h
+++ b/include/itkConfidenceConnectedSegmentationModule.h
@@ -37,6 +37,8 @@ class ITK_EXPORT ConfidenceConnectedSegmentationModule :
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConfidenceConnectedSegmentationModule);
+
   /** Standard class type alias. */
   using Self = ConfidenceConnectedSegmentationModule;
   using Superclass = RegionGrowingSegmentationModule<NDimension>;
@@ -73,9 +75,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  ConfidenceConnectedSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   double        m_SigmaMultiplier;
 
 };

--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -37,6 +37,8 @@ class ITK_EXPORT ConnectedThresholdSegmentationModule :
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConfidenceConnectedSegmentationModule);
+
   /** Standard class type alias. */
   using Self = ConnectedThresholdSegmentationModule;
   using Superclass = RegionGrowingSegmentationModule<NDimension>;
@@ -74,9 +76,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  ConnectedThresholdSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   double        m_LowerThreshold;
   double        m_UpperThreshold;
   

--- a/include/itkDescoteauxSheetnessFeatureGenerator.h
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.h
@@ -44,6 +44,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT DescoteauxSheetnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxSheetnessFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = DescoteauxSheetnessFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -109,9 +111,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  DescoteauxSheetnessFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -178,6 +178,8 @@ UnaryFunctorImageFilter<TInputImage,TOutputImage,
                                        typename TOutputImage::PixelType>   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxSheetnessImageFilter);
+
   /** Standard class type alias. */
   using Self = DescoteauxSheetnessImageFilter;
   using Superclass = UnaryFunctorImageFilter<
@@ -234,11 +236,6 @@ public:
 protected:
   DescoteauxSheetnessImageFilter() {}
   ~DescoteauxSheetnessImageFilter() override {}
-
-private:
-  DescoteauxSheetnessImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -39,6 +39,8 @@ class ITK_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule 
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule);
+
   /** Standard class type alias. */
   using Self = FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule;
   using Superclass = SinglePhaseLevelSetSegmentationModule<NDimension>;
@@ -97,10 +99,6 @@ protected:
   typename FastMarchingModuleType::Pointer m_FastMarchingModule;
   using GeodesicActiveContourLevelSetModuleType = GeodesicActiveContourLevelSetSegmentationModule< Dimension >;
   typename GeodesicActiveContourLevelSetModuleType::Pointer m_GeodesicActiveContourLevelSetModule;
-
-private:
-  FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 };
 
 } // end namespace itk

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
@@ -39,6 +39,8 @@ class ITK_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingAndShapeDetectionLevelSetSegmentationModule);
+
   /** Standard class type alias. */
   using Self = FastMarchingAndShapeDetectionLevelSetSegmentationModule;
   using Superclass = SinglePhaseLevelSetSegmentationModule<NDimension>;
@@ -97,10 +99,6 @@ protected:
   typename FastMarchingModuleType::Pointer m_FastMarchingModule;
   using ShapeDetectionLevelSetModuleType = ShapeDetectionLevelSetSegmentationModule< Dimension >;
   typename ShapeDetectionLevelSetModuleType::Pointer m_ShapeDetectionLevelSetModule;
-
-private:
-  FastMarchingAndShapeDetectionLevelSetSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 };
 
 } // end namespace itk

--- a/include/itkFastMarchingSegmentationModule.h
+++ b/include/itkFastMarchingSegmentationModule.h
@@ -38,6 +38,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT FastMarchingSegmentationModule : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingSegmentationModule);
+
   /** Standard class type alias. */
   using Self = FastMarchingSegmentationModule;
   using Superclass = SinglePhaseLevelSetSegmentationModule<NDimension>;
@@ -95,11 +97,6 @@ protected:
 
   double m_StoppingValue;
   double m_DistanceFromSeeds;
-
-private:
-  FastMarchingSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -40,6 +40,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT FeatureAggregator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FeatureAggregator);
+
   /** Standard class type alias. */
   using Self = FeatureAggregator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -96,9 +98,6 @@ protected:
   ProgressAccumulator::Pointer              m_ProgressAccumulator;
 
 private:
-  FeatureAggregator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using FeatureGeneratorPointer = typename FeatureGeneratorType::Pointer;
   using FeatureGeneratorArrayType = std::vector< FeatureGeneratorPointer >;
   using FeatureGeneratorIterator = typename FeatureGeneratorArrayType::iterator;

--- a/include/itkFeatureGenerator.h
+++ b/include/itkFeatureGenerator.h
@@ -40,6 +40,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT FeatureGenerator : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FeatureGenerator);
+
   /** Standard class type alias. */
   using Self = FeatureGenerator;
   using Superclass = ProcessObject;
@@ -79,11 +81,6 @@ protected:
 
   /** non-const version of the method intended to be used in derived classes. */
   SpatialObjectType * GetInternalFeature();
-
-private:
-  FeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkFrangiTubularnessFeatureGenerator.h
+++ b/include/itkFrangiTubularnessFeatureGenerator.h
@@ -42,6 +42,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT FrangiTubularnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrangiTubularnessFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = FrangiTubularnessFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -101,9 +103,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  FrangiTubularnessFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -186,6 +186,8 @@ UnaryFunctorImageFilter<TInputImage,TOutputImage,
                                        typename TOutputImage::PixelType>   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrangiTubularnessImageFilter);
+
   /** Standard class type alias. */
   using Self = FrangiTubularnessImageFilter;
   using Superclass = UnaryFunctorImageFilter<
@@ -242,11 +244,6 @@ public:
 protected:
   FrangiTubularnessImageFilter() {}
   ~FrangiTubularnessImageFilter() override {}
-
-private:
-  FrangiTubularnessImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -37,6 +37,8 @@ class ITK_EXPORT GeodesicActiveContourLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(GeodesicActiveContourLevelSetSegmentationModule);
+
   /** Standard class type alias. */
   using Self = GeodesicActiveContourLevelSetSegmentationModule;
   using Superclass = SinglePhaseLevelSetSegmentationModule<NDimension>;
@@ -75,11 +77,6 @@ protected:
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
   void  GenerateData () override;
-
-private:
-  GeodesicActiveContourLevelSetSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
@@ -42,6 +42,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT GradientMagnitudeSigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(GradientMagnitudeSigmoidFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = GradientMagnitudeSigmoidFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -97,9 +99,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  GradientMagnitudeSigmoidFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.h
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.h
@@ -44,6 +44,8 @@ class ITK_EXPORT GrayscaleImageSegmentationVolumeEstimator :
  public SegmentationVolumeEstimator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(GrayscaleImageSegmentationVolumeEstimator);
+
   /** Standard class type alias. */
   using Self = GrayscaleImageSegmentationVolumeEstimator;
   using Superclass = SegmentationVolumeEstimator<NDimension>;
@@ -80,11 +82,6 @@ protected:
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
   void  GenerateData() override;
-
-private:
-  GrayscaleImageSegmentationVolumeEstimator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkIsotropicResampler.h
+++ b/include/itkIsotropicResampler.h
@@ -38,6 +38,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT IsotropicResampler : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicResampler);
+
   /** Standard class type alias. */
   using Self = IsotropicResampler;
   using Superclass = ProcessObject;
@@ -84,9 +86,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  IsotropicResampler(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using OutputPixelType = signed short;
   using OutputImageType = Image< OutputPixelType, Dimension >;
 

--- a/include/itkIsotropicResamplerImageFilter.h
+++ b/include/itkIsotropicResamplerImageFilter.h
@@ -39,6 +39,8 @@ class IsotropicResamplerImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicResamplerImageFilter);
+
   /** Standard "Self" & Superclass type alias.  */
   using Self = IsotropicResamplerImageFilter;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
@@ -99,8 +101,6 @@ protected:
 
 private:
   ~IsotropicResamplerImageFilter() override;
-  IsotropicResamplerImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 
   SpacingType m_OutputSpacing;
   using ResampleFilterType = ResampleImageFilter< TInputImage, TOutputImage >;

--- a/include/itkLandmarksReader.h
+++ b/include/itkLandmarksReader.h
@@ -37,6 +37,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT LandmarksReader : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LandmarksReader);
+
   /** Standard class type alias. */
   using Self = LandmarksReader;
   using Superclass = ProcessObject;
@@ -73,10 +75,6 @@ protected:
   void GenerateData() override;
 
 private:
-  LandmarksReader(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
-
   using SpatialObjectReaderType = SpatialObjectReader< NDimension, unsigned short >;
   using SpatialObjectReaderPointer = typename SpatialObjectReaderType::Pointer;
   using SceneType = typename SpatialObjectReaderType::SceneType;

--- a/include/itkLesionSegmentationMethod.h
+++ b/include/itkLesionSegmentationMethod.h
@@ -43,6 +43,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT LesionSegmentationMethod : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LesionSegmentationMethod);
+
   /** Standard class type alias. */
   using Self = LesionSegmentationMethod;
   using Superclass = ProcessObject;
@@ -107,9 +109,6 @@ protected:
   void  GenerateData() override;
 
 private:
-  LesionSegmentationMethod(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   SpatialObjectConstPointer                 m_RegionOfInterest;
   SpatialObjectConstPointer                 m_InitialSegmentation;
   

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -169,6 +169,8 @@ UnaryFunctorImageFilter<TInputImage,TOutputImage,
                                        typename TOutputImage::PixelType>   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LocalStructureImageFilter);
+
   /** Standard class type alias. */
   using Self = LocalStructureImageFilter;
   using Superclass = UnaryFunctorImageFilter<
@@ -212,11 +214,6 @@ public:
 protected:
   LocalStructureImageFilter() {}
   ~LocalStructureImageFilter() override {}
-
-private:
-  LocalStructureImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkLungWallFeatureGenerator.h
+++ b/include/itkLungWallFeatureGenerator.h
@@ -43,6 +43,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT LungWallFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LungWallFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = LungWallFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -89,9 +91,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  LungWallFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkMaximumFeatureAggregator.h
+++ b/include/itkMaximumFeatureAggregator.h
@@ -42,6 +42,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT MaximumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MaximumFeatureAggregator);
+
   /** Standard class type alias. */
   using Self = MaximumFeatureAggregator;
   using Superclass = FeatureAggregator<NDimension>;
@@ -70,9 +72,6 @@ protected:
 
 
 private:
-  MaximumFeatureAggregator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   void ConsolidateFeatures() override;
 
 };

--- a/include/itkMinimumFeatureAggregator.h
+++ b/include/itkMinimumFeatureAggregator.h
@@ -42,6 +42,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT MinimumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MinimumFeatureAggregator);
+
   /** Standard class type alias. */
   using Self = MinimumFeatureAggregator;
   using Superclass = FeatureAggregator<NDimension>;
@@ -70,9 +72,6 @@ protected:
 
 
 private:
-  MinimumFeatureAggregator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   void ConsolidateFeatures() override;
 
 };

--- a/include/itkMorphologicalOpenningFeatureGenerator.h
+++ b/include/itkMorphologicalOpenningFeatureGenerator.h
@@ -46,6 +46,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT MorphologicalOpenningFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalOpenningFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = MorphologicalOpenningFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -92,9 +94,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  MorphologicalOpenningFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = unsigned char;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkRegionCompetitionImageFilter.h
+++ b/include/itkRegionCompetitionImageFilter.h
@@ -42,6 +42,8 @@ class RegionCompetitionImageFilter:
     public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RegionCompetitionImageFilter);
+
   /** Standard class type alias. */
   using Self = RegionCompetitionImageFilter;
   using Superclass = ImageToImageFilter<TInputImage,TOutputImage>;
@@ -107,10 +109,6 @@ protected:
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
-  RegionCompetitionImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
-
   void AllocateOutputImageWorkingMemory();
 
   void AllocateFrontsWorkingMemory();

--- a/include/itkRegionGrowingSegmentationModule.h
+++ b/include/itkRegionGrowingSegmentationModule.h
@@ -36,6 +36,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT RegionGrowingSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RegionGrowingSegmentationModule);
+
   /** Standard class type alias. */
   using Self = RegionGrowingSegmentationModule;
   using Superclass = SegmentationModule<NDimension>;
@@ -88,9 +90,6 @@ protected:
   const FeatureImageType * GetInternalFeatureImage() const;
 
 private:
-  RegionGrowingSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   void ConvertIntensitiesToCenteredRange( OutputImageType * outputImage );
 };
 

--- a/include/itkSatoLocalStructureFeatureGenerator.h
+++ b/include/itkSatoLocalStructureFeatureGenerator.h
@@ -42,6 +42,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SatoLocalStructureFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SatoLocalStructureFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = SatoLocalStructureFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -97,9 +99,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  SatoLocalStructureFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkSatoVesselnessFeatureGenerator.h
+++ b/include/itkSatoVesselnessFeatureGenerator.h
@@ -44,6 +44,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SatoVesselnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = SatoVesselnessFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -104,9 +106,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  SatoVesselnessFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.h
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.h
@@ -39,6 +39,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SatoVesselnessSigmoidFeatureGenerator : public SatoVesselnessFeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessSigmoidFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = SatoVesselnessSigmoidFeatureGenerator;
   using Superclass = SatoVesselnessFeatureGenerator<NDimension>;
@@ -76,9 +78,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  SatoVesselnessSigmoidFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using InternalPixelType = float;
   using InternalImageType = Image< InternalPixelType, Dimension >;
 

--- a/include/itkSegmentationModule.h
+++ b/include/itkSegmentationModule.h
@@ -40,6 +40,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SegmentationModule : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationModule);
+
   /** Standard class type alias. */
   using Self = SegmentationModule;
   using Superclass = ProcessObject;
@@ -87,11 +89,6 @@ protected:
   /** Output segmentation represented as a SpatialObject. Non-const version
    * only for internal use. */
   SpatialObjectType * GetInternalOutput();
-
-private:
-  SegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkSegmentationVolumeEstimator.h
+++ b/include/itkSegmentationVolumeEstimator.h
@@ -38,6 +38,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SegmentationVolumeEstimator : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationVolumeEstimator);
+
   /** Standard class type alias. */
   using Self = SegmentationVolumeEstimator;
   using Superclass = ProcessObject;
@@ -83,11 +85,6 @@ protected:
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
   void  GenerateData() override;
-
-private:
-  SegmentationVolumeEstimator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.h
@@ -37,6 +37,8 @@ class ITK_EXPORT ShapeDetectionLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ShapeDetectionLevelSetSegmentationModule);
+
   /** Standard class type alias. */
   using Self = ShapeDetectionLevelSetSegmentationModule;
   using Superclass = SinglePhaseLevelSetSegmentationModule<NDimension>;
@@ -75,11 +77,6 @@ protected:
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
   void  GenerateData () override;
-
-private:
-  ShapeDetectionLevelSetSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk

--- a/include/itkSigmoidFeatureGenerator.h
+++ b/include/itkSigmoidFeatureGenerator.h
@@ -43,6 +43,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SigmoidFeatureGenerator);
+
   /** Standard class type alias. */
   using Self = SigmoidFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
@@ -93,9 +95,6 @@ protected:
   void  GenerateData () override;
 
 private:
-  SigmoidFeatureGenerator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   using OutputPixelType = float;
   using OutputImageType = Image< OutputPixelType, Dimension >;
 

--- a/include/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.h
@@ -35,6 +35,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT SinglePhaseLevelSetSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SinglePhaseLevelSetSegmentationModule);
+
   /** Standard class type alias. */
   using Self = SinglePhaseLevelSetSegmentationModule;
   using Superclass = SegmentationModule<NDimension>;
@@ -122,9 +124,6 @@ protected:
   const FeatureImageType * GetInternalFeatureImage() const;
 
 private:
-  SinglePhaseLevelSetSegmentationModule(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   double        m_PropagationScaling;
   double        m_CurvatureScaling;
   double        m_AdvectionScaling;

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -77,6 +77,8 @@ class ITK_EXPORT VesselEnhancingDiffusion3DImageFilter :
 {
 
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VesselEnhancingDiffusion3DImageFilter);
+
   using Precision = float;
   using ImageType = Image<PixelType, NDimension>;
   using PrecisionImageType = Image<Precision,NDimension>;
@@ -142,10 +144,6 @@ protected:
   void GenerateData() override;
 
 private:
-
-  VesselEnhancingDiffusion3DImageFilter(const Self&);
-  void operator=(const Self&);
-
   Precision                 m_TimeStep;
   unsigned int              m_Iterations;
   unsigned int              m_RecalculateVesselness;

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -41,6 +41,8 @@ class ITK_EXPORT VotingBinaryHoleFillFloodingImageFilter:
     public VotingBinaryImageFilter<TInputImage,TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(VotingBinaryHoleFillFloodingImageFilter);
+
   /** Standard class type alias. */
   using Self = VotingBinaryHoleFillFloodingImageFilter;
   using Superclass = VotingBinaryImageFilter<TInputImage,TOutputImage>;
@@ -113,10 +115,6 @@ protected:
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
-  VotingBinaryHoleFillFloodingImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
-
   void AllocateOutputImageWorkingMemory();
 
   void InitializeNeighborhood();

--- a/include/itkWeightedSumFeatureAggregator.h
+++ b/include/itkWeightedSumFeatureAggregator.h
@@ -44,6 +44,8 @@ template <unsigned int NDimension>
 class ITK_EXPORT WeightedSumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(WeightedSumFeatureAggregator);
+
   /** Standard class type alias. */
   using Self = WeightedSumFeatureAggregator;
   using Superclass = FeatureAggregator<NDimension>;
@@ -73,11 +75,7 @@ protected:
   ~WeightedSumFeatureAggregator() override;
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
-
 private:
-  WeightedSumFeatureAggregator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   void ConsolidateFeatures() override;
 
   using WeightsArrayType = std::vector< double >;


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.