### PR TITLE
BUG: Use ITK_TEMPLATE_EXPORT macro instead of ITK_EXPORT.

### DIFF
--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -89,7 +89,7 @@ public:
  * \sa ZeroCrossingImageFilter
  * \sa ThresholdImageFilter */
 template<class TInputImage, class TOutputImage>
-class ITK_EXPORT CannyEdgeDetectionRecursiveGaussianImageFilter
+class ITK_TEMPLATE_EXPORT CannyEdgeDetectionRecursiveGaussianImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
@@ -64,7 +64,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT CannyEdgesDistanceAdvectionFieldFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT CannyEdgesDistanceAdvectionFieldFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceAdvectionFieldFeatureGenerator);

--- a/include/itkCannyEdgesDistanceFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceFeatureGenerator.h
@@ -59,7 +59,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT CannyEdgesDistanceFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT CannyEdgesDistanceFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceFeatureGenerator);

--- a/include/itkCannyEdgesFeatureGenerator.h
+++ b/include/itkCannyEdgesFeatureGenerator.h
@@ -57,7 +57,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT CannyEdgesFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT CannyEdgesFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesFeatureGenerator);

--- a/include/itkConfidenceConnectedSegmentationModule.h
+++ b/include/itkConfidenceConnectedSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT ConfidenceConnectedSegmentationModule :
+class ITK_TEMPLATE_EXPORT ConfidenceConnectedSegmentationModule :
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:

--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT ConnectedThresholdSegmentationModule : 
+class ITK_TEMPLATE_EXPORT ConnectedThresholdSegmentationModule : 
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:

--- a/include/itkDescoteauxSheetnessFeatureGenerator.h
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT DescoteauxSheetnessFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT DescoteauxSheetnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxSheetnessFeatureGenerator);

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -171,7 +171,7 @@ private:
 }
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT DescoteauxSheetnessImageFilter :
+class ITK_TEMPLATE_EXPORT DescoteauxSheetnessImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage, 
                         Function::Sheetness< typename TInputImage::PixelType, 

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule : 
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModule : 
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkFastMarchingSegmentationModule.h
+++ b/include/itkFastMarchingSegmentationModule.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FastMarchingSegmentationModule : public SinglePhaseLevelSetSegmentationModule<NDimension>
+class ITK_TEMPLATE_EXPORT FastMarchingSegmentationModule : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingSegmentationModule);

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FeatureAggregator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT FeatureAggregator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(FeatureAggregator);

--- a/include/itkFeatureGenerator.h
+++ b/include/itkFeatureGenerator.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FeatureGenerator : public ProcessObject
+class ITK_TEMPLATE_EXPORT FeatureGenerator : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(FeatureGenerator);

--- a/include/itkFrangiTubularnessFeatureGenerator.h
+++ b/include/itkFrangiTubularnessFeatureGenerator.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT FrangiTubularnessFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT FrangiTubularnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(FrangiTubularnessFeatureGenerator);

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -179,7 +179,7 @@ private:
 }
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT FrangiTubularnessImageFilter :
+class ITK_TEMPLATE_EXPORT FrangiTubularnessImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage, 
                         Function::Tubularness< typename TInputImage::PixelType, 

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT GeodesicActiveContourLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT GeodesicActiveContourLevelSetSegmentationModule : 
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT GradientMagnitudeSigmoidFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT GradientMagnitudeSigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(GradientMagnitudeSigmoidFeatureGenerator);

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.h
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT GrayscaleImageSegmentationVolumeEstimator :
+class ITK_TEMPLATE_EXPORT GrayscaleImageSegmentationVolumeEstimator :
  public SegmentationVolumeEstimator<NDimension>
 {
 public:

--- a/include/itkIsotropicResampler.h
+++ b/include/itkIsotropicResampler.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT IsotropicResampler : public ProcessObject
+class ITK_TEMPLATE_EXPORT IsotropicResampler : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicResampler);

--- a/include/itkLandmarksReader.h
+++ b/include/itkLandmarksReader.h
@@ -34,7 +34,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT LandmarksReader : public ProcessObject
+class ITK_TEMPLATE_EXPORT LandmarksReader : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(LandmarksReader);

--- a/include/itkLesionSegmentationMethod.h
+++ b/include/itkLesionSegmentationMethod.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT LesionSegmentationMethod : public ProcessObject
+class ITK_TEMPLATE_EXPORT LesionSegmentationMethod : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(LesionSegmentationMethod);

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -162,7 +162,7 @@ private:
 }
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LocalStructureImageFilter :
+class ITK_TEMPLATE_EXPORT LocalStructureImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage,
                         Function::LocalStructure< typename TInputImage::PixelType,

--- a/include/itkLungWallFeatureGenerator.h
+++ b/include/itkLungWallFeatureGenerator.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT LungWallFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT LungWallFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(LungWallFeatureGenerator);

--- a/include/itkMaximumFeatureAggregator.h
+++ b/include/itkMaximumFeatureAggregator.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT MaximumFeatureAggregator : public FeatureAggregator<NDimension>
+class ITK_TEMPLATE_EXPORT MaximumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MaximumFeatureAggregator);

--- a/include/itkMinimumFeatureAggregator.h
+++ b/include/itkMinimumFeatureAggregator.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT MinimumFeatureAggregator : public FeatureAggregator<NDimension>
+class ITK_TEMPLATE_EXPORT MinimumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MinimumFeatureAggregator);

--- a/include/itkMorphologicalOpenningFeatureGenerator.h
+++ b/include/itkMorphologicalOpenningFeatureGenerator.h
@@ -43,7 +43,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT MorphologicalOpenningFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT MorphologicalOpenningFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalOpenningFeatureGenerator);

--- a/include/itkRegionGrowingSegmentationModule.h
+++ b/include/itkRegionGrowingSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT RegionGrowingSegmentationModule : public SegmentationModule<NDimension>
+class ITK_TEMPLATE_EXPORT RegionGrowingSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(RegionGrowingSegmentationModule);

--- a/include/itkSatoLocalStructureFeatureGenerator.h
+++ b/include/itkSatoLocalStructureFeatureGenerator.h
@@ -39,7 +39,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SatoLocalStructureFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT SatoLocalStructureFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SatoLocalStructureFeatureGenerator);

--- a/include/itkSatoVesselnessFeatureGenerator.h
+++ b/include/itkSatoVesselnessFeatureGenerator.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SatoVesselnessFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT SatoVesselnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessFeatureGenerator);

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.h
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SatoVesselnessSigmoidFeatureGenerator : public SatoVesselnessFeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT SatoVesselnessSigmoidFeatureGenerator : public SatoVesselnessFeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessSigmoidFeatureGenerator);

--- a/include/itkSegmentationModule.h
+++ b/include/itkSegmentationModule.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SegmentationModule : public ProcessObject
+class ITK_TEMPLATE_EXPORT SegmentationModule : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationModule);

--- a/include/itkSegmentationVolumeEstimator.h
+++ b/include/itkSegmentationVolumeEstimator.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SegmentationVolumeEstimator : public ProcessObject
+class ITK_TEMPLATE_EXPORT SegmentationVolumeEstimator : public ProcessObject
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationVolumeEstimator);

--- a/include/itkShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT ShapeDetectionLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT ShapeDetectionLevelSetSegmentationModule : 
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkSigmoidFeatureGenerator.h
+++ b/include/itkSigmoidFeatureGenerator.h
@@ -40,7 +40,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SigmoidFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT SigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SigmoidFeatureGenerator);

--- a/include/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.h
@@ -32,7 +32,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT SinglePhaseLevelSetSegmentationModule : public SegmentationModule<NDimension>
+class ITK_TEMPLATE_EXPORT SinglePhaseLevelSetSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(SinglePhaseLevelSetSegmentationModule);

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -71,7 +71,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
 */
 template <class PixelType = short int, unsigned int NDimension = 3>
-class ITK_EXPORT VesselEnhancingDiffusion3DImageFilter :
+class ITK_TEMPLATE_EXPORT VesselEnhancingDiffusion3DImageFilter :
     public ImageToImageFilter<Image<PixelType, NDimension> ,
                               Image<PixelType, NDimension> >
 {

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT VotingBinaryHoleFillFloodingImageFilter:
+class ITK_TEMPLATE_EXPORT VotingBinaryHoleFillFloodingImageFilter:
     public VotingBinaryImageFilter<TInputImage,TOutputImage>
 {
 public:

--- a/include/itkWeightedSumFeatureAggregator.h
+++ b/include/itkWeightedSumFeatureAggregator.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_EXPORT WeightedSumFeatureAggregator : public FeatureAggregator<NDimension>
+class ITK_TEMPLATE_EXPORT WeightedSumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(WeightedSumFeatureAggregator);


### PR DESCRIPTION
`ITK_EXPORT` has no known use:
https://github.com/InsightSoftwareConsortium/ITK/commit/b788601abbeebd72e5504b10a75a9f417f666c35

and the templated class visibility is managed by the `ITK_TEMPLATE_EXPORT`
macro since commit:
https://github.com/InsightSoftwareConsortium/ITK/commit/be14aef1ec8646982fa717b7a88b8f1b60558717