### PR TITLE
BUG: Fix DISALLOW_COPY_AND_ASSIGN macro argument.

### DIFF
--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -37,7 +37,7 @@ class ITK_EXPORT ConnectedThresholdSegmentationModule :
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConfidenceConnectedSegmentationModule);
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConnectedThresholdSegmentationModule);
 
   /** Standard class type alias. */
   using Self = ConnectedThresholdSegmentationModule;


### PR DESCRIPTION
Fix `DISALLOW_COPY_AND_ASSIGN` macro agument for the
`itk::ConnectedThresholdSegmentationModule` class.

Fixes compilation errors (MSVC 2015):
```
1>c:\sources\lesionsizingtoolkit\include\itkConnectedThresholdSegmentationModule.h(40):
error C2059: syntax error: 'const'
1>
c:\sources\lesionsizingtoolkit\include\itkConnectedThresholdSegmentationModule.h(82):
note: see reference to class template instantiation
'itk::ConnectedThresholdSegmentationModule<NDimension>' being compiled
1>c:\sources\lesionsizingtoolkit\include\itkConnectedThresholdSegmentationModule.h(40):
error C2238: unexpected token(s) preceding ';'
```