### PR TITLE
COMP: fix linking errors due to missing modules

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -14,8 +14,10 @@ itk_module(LesionSizingToolkit
    ITKRegionGrowing
    ITKLabelVoting
    ITKMathematicalMorphology
+   ITKIOBruker
    ITKIOGDCM
    ITKIOMeta
+   ITKIOMINC
    ITKIOGE
    ITKIOBioRad
    ITKIOHDF5


### PR DESCRIPTION
This remote module does not build with legacy off. The errors stem from copied and maybe slightly customized Canny filter. The correct way would be to inherit from the regular Canny filter, but I guess that will have to wait.