### PR TITLE
ENH: Adapt to new multi-threading naming convention.

### DIFF
--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -285,10 +285,10 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
   
   int total, threadId, threadCount;
   
-  threadId = ((MultiThreader::ThreadInfoStruct *)(arg))->ThreadID;
-  threadCount = ((MultiThreader::ThreadInfoStruct *)(arg))->NumberOfThreads;
+  threadId = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
   
-  str = (CannyThreadStruct *)(((MultiThreader::ThreadInfoStruct *)(arg))->UserData);
+  str = (CannyThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.
@@ -617,10 +617,10 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
   
   int total, threadId, threadCount;
   
-  threadId = ((MultiThreader::ThreadInfoStruct *)(arg))->ThreadID;
-  threadCount = ((MultiThreader::ThreadInfoStruct *)(arg))->NumberOfThreads;
+  threadId = ((MultiThreaderBase::WorkUnitInfo *)(arg))->WorkUnitID;
+  threadCount = ((MultiThreaderBase::WorkUnitInfo *)(arg))->NumberOfWorkUnits;
   
-  str = (CannyThreadStruct *)(((MultiThreader::ThreadInfoStruct *)(arg))->UserData);
+  str = (CannyThreadStruct *)(((MultiThreaderBase::WorkUnitInfo *)(arg))->UserData);
 
   // Execute the actual method with appropriate output region
   // first find out how many pieces extent can be split into.


### PR DESCRIPTION
Adapt to new multi-threading naming convention. Specifically:
- Change `MultiThreader::ThreadInfoStruct` to
  `MultiThreaderBase::WorkUnitInfo`
- Change `(threadInfo)->ThreadID` to `(threadInfo)->WorkUnitID`
- Change `(threadInfo)->NumberOfThreads` to
  `(threadInfo)->NumberOfWorkUnits`

after commit:
https://github.com/InsightSoftwareConsortium/ITK/commit/ce15429a230a82617af1e19fd9a6964e9fc65d1d

Addresses deprecation warnings:
```
lesionsizingtoolkit\include\itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx(288):
warning C4996: 'itk::MultiThreaderBase::ThreadInfoStruct': Use
WorkUnitInfo, ThreadInfoStruct is deprecated since ITK 5.0
```