### PR TITLE
DOC: Fix Doxygen generation breaking non-ASCII character.

### DIFF
--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -32,7 +32,7 @@ namespace itk
  * M.Descoteaux, M.Audette, K.Chinzei, el al.: 
  * "Bone enhancement filtering: Application to sinus bone segmentation
  *  and simulation of pituitary surgery."
- *  In: MICCAI.  (2005) 9–16
+ *  In: MICCAI.  (2005) 9-16
  *
  * \ingroup IntensityImageFilters  Multithreaded
  * \ingroup LesionSizingToolkit


### PR DESCRIPTION
Fix Doxygen documentation generation breaking non-ASCII character: change
en dash (0x96 Hex; U+2012) for the hyphen-minus (ASCII 45; U+002D).

Solves the error:
```
/.../ITK/Modules/Remote/LabelErodeDilate/include/itkLabelSetMorphBaseImageFilt/
.../ITK/Modules/Remote/LesionSizingToolkit/include/.!21046!itkDescoteauxSheetnessImageFilter.h:35:
warning: File ended in the middle of a comment block! Perhaps a missing
\endcode?
```
or

```
UnicodeDecodeError: 'utf8' codec can't decode byte 0x96 in position 1230:
invalid start byte
```

reported in
https://open.cdash.org/viewBuildError.php?type=1&buildid=5556519
and
https://open.cdash.org/testDetails.php?test=650459767&build=5556519