### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
 {
 
 
-template <class TValueType>
+template <typename TValueType>
 class ListNode
 {
 public:
@@ -88,7 +88,7 @@ public:
  * \sa SmoothingRecursiveGaussianImageFilter
  * \sa ZeroCrossingImageFilter
  * \sa ThresholdImageFilter */
-template<class TInputImage, class TOutputImage>
+template<typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT CannyEdgeDetectionRecursiveGaussianImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -27,7 +27,7 @@
 namespace itk
 {
   
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>::
 CannyEdgeDetectionRecursiveGaussianImageFilter()
 {
@@ -80,7 +80,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter()
   m_NodeList = ListType::New();
 }
  
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 ::AllocateUpdateBuffer()
@@ -95,7 +95,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
   m_UpdateBuffer1->Allocate();  
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
 ::GenerateInputRequestedRegion() throw(InvalidRequestedRegionError)
@@ -150,7 +150,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
     }
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::ThreadedCompute2ndDerivative(const OutputImageRegionType&
@@ -204,7 +204,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 typename CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::OutputImagePixelType
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
@@ -262,7 +262,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 }
 
 // Calculate the second derivative
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::Compute2ndDerivative() 
@@ -276,7 +276,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
   this->GetMultiThreader()->SingleMethodExecute();
 }
 
-template<class TInputImage, class TOutputImage>
+template<typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_TYPE
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 ::Compute2ndDerivativeThreaderCallback( void * arg )
@@ -305,7 +305,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
   return ITK_THREAD_RETURN_VALUE;
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::GenerateData()
@@ -363,7 +363,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
   this->HysteresisThresholding();
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::HysteresisThresholding()
@@ -405,7 +405,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
     }
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::FollowEdge(IndexType index)
@@ -468,7 +468,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
     }
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 bool
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::InBounds(IndexType index)
@@ -489,7 +489,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::ThreadedCompute2ndDerivativePos(const OutputImageRegionType& outputRegionForThread, int threadId)
@@ -594,7 +594,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 }
 
 //Calculate the second derivative
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void 
 CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
 ::Compute2ndDerivativePos() 
@@ -608,7 +608,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
   this->GetMultiThreader()->SingleMethodExecute();
 }
 
-template<class TInputImage, class TOutputImage>
+template<typename TInputImage, typename TOutputImage>
 ITK_THREAD_RETURN_TYPE
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 ::Compute2ndDerivativePosThreaderCallback( void * arg )
@@ -686,7 +686,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -39,7 +39,7 @@ namespace itk
  */
 namespace Function {  
   
-template< class TInput, class TOutput>
+template< typename TInput, typename TOutput>
 class Sheetness
 {
 public:
@@ -170,7 +170,7 @@ private:
 }; 
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT DescoteauxSheetnessImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage, 

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  */
 namespace Function {  
   
-template< class TInput, class TOutput>
+template< typename TInput, typename TOutput>
 class Tubularness
 {
 public:
@@ -178,7 +178,7 @@ private:
 }; 
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT FrangiTubularnessImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage, 

--- a/include/itkIsotropicResamplerImageFilter.h
+++ b/include/itkIsotropicResamplerImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  *\ingroup LesionSizingToolkit
  * \ingroup LesionSizingToolkit
  */
-template<class TInputImage, class TOutputImage>
+template<typename TInputImage, typename TOutputImage>
 class IsotropicResamplerImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/include/itkIsotropicResamplerImageFilter.hxx
+++ b/include/itkIsotropicResamplerImageFilter.hxx
@@ -23,7 +23,7 @@
 namespace itk
 {
   
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 IsotropicResamplerImageFilter<TInputImage, TOutputImage>::
 IsotropicResamplerImageFilter()
 {
@@ -35,13 +35,13 @@ IsotropicResamplerImageFilter()
   this->m_ResampleFilter = ResampleFilterType::New();
 }
   
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 IsotropicResamplerImageFilter<TInputImage, TOutputImage>::
 ~IsotropicResamplerImageFilter()
 {
 }
  
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 IsotropicResamplerImageFilter< TInputImage, TOutputImage >
 ::GenerateOutputInformation()
@@ -85,7 +85,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
 #endif
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 IsotropicResamplerImageFilter< TInputImage, TOutputImage >
 ::GenerateData()
@@ -146,7 +146,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
   this->GraftOutput( this->m_ResampleFilter->GetOutput() );
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void IsotropicResamplerImageFilter< TInputImage,TOutputImage >
 ::SetAbortGenerateData( const bool abort )
 {
@@ -155,7 +155,7 @@ void IsotropicResamplerImageFilter< TInputImage,TOutputImage >
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 IsotropicResamplerImageFilter<TInputImage,TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const

--- a/include/itkLesionSegmentationImageFilter8.h
+++ b/include/itkLesionSegmentationImageFilter8.h
@@ -41,7 +41,7 @@ namespace itk
 /** \class LesionSegmentationImageFilter8
  * \ingroup LesionSizingToolkit
  */
-template<class TInputImage, class TOutputImage>
+template<typename TInputImage, typename TOutputImage>
 class LesionSegmentationImageFilter8
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {

--- a/include/itkLesionSegmentationImageFilter8.hxx
+++ b/include/itkLesionSegmentationImageFilter8.hxx
@@ -27,7 +27,7 @@
 namespace itk
 {
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 LesionSegmentationImageFilter8<TInputImage, TOutputImage>::
 LesionSegmentationImageFilter8()
 {
@@ -99,7 +99,7 @@ LesionSegmentationImageFilter8()
   m_UserSpecifiedSigmas = false;
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 LesionSegmentationImageFilter8<TInputImage,TOutputImage>
 ::GenerateInputRequestedRegion() throw(InvalidRequestedRegionError)
@@ -117,7 +117,7 @@ LesionSegmentationImageFilter8<TInputImage,TOutputImage>
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 LesionSegmentationImageFilter8<TInputImage,TOutputImage>
 ::SetSigma( SigmaArrayType s )
@@ -126,7 +126,7 @@ LesionSegmentationImageFilter8<TInputImage,TOutputImage>
   m_CannyEdgesFeatureGenerator->SetSigmaArray(s);
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 LesionSegmentationImageFilter8<TInputImage,TOutputImage>
 ::GenerateOutputInformation()
@@ -177,7 +177,7 @@ LesionSegmentationImageFilter8<TInputImage,TOutputImage>
 }
 
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 void
 LesionSegmentationImageFilter8< TInputImage, TOutputImage >
 ::GenerateData()
@@ -258,7 +258,7 @@ LesionSegmentationImageFilter8< TInputImage, TOutputImage >
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void LesionSegmentationImageFilter8< TInputImage,TOutputImage >
 ::ProgressUpdate( Object * caller,
                   const EventObject & e )
@@ -311,7 +311,7 @@ void LesionSegmentationImageFilter8< TInputImage,TOutputImage >
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void LesionSegmentationImageFilter8< TInputImage,TOutputImage >
 ::SetAbortGenerateData( bool abort )
 {
@@ -321,14 +321,14 @@ void LesionSegmentationImageFilter8< TInputImage,TOutputImage >
   this->m_LesionSegmentationMethod->SetAbortGenerateData(abort);
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void LesionSegmentationImageFilter8< TInputImage,TOutputImage >
 ::SetUseVesselEnhancingDiffusion( bool b )
 {
   this->m_VesselnessFeatureGenerator->SetUseVesselEnhancingDiffusion(b);
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 LesionSegmentationImageFilter8<TInputImage,TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -46,7 +46,7 @@ namespace itk
  */
 namespace Function {
 
-template< class TInput, class TOutput>
+template< typename TInput, typename TOutput>
 class LocalStructure
 {
 public:
@@ -161,7 +161,7 @@ private:
 };
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT LocalStructureImageFilter :
     public
 UnaryFunctorImageFilter<TInputImage,TOutputImage,

--- a/include/itkRegionCompetitionImageFilter.h
+++ b/include/itkRegionCompetitionImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  * \ingroup RegionGrowingSegmentation
  * \ingroup LesionSizingToolkit
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class RegionCompetitionImageFilter:
     public ImageToImageFilter<TInputImage,TOutputImage>
 {

--- a/include/itkRegionCompetitionImageFilter.hxx
+++ b/include/itkRegionCompetitionImageFilter.hxx
@@ -30,7 +30,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 RegionCompetitionImageFilter<TInputImage, TOutputImage>
 ::RegionCompetitionImageFilter()
 {
@@ -57,7 +57,7 @@ RegionCompetitionImageFilter<TInputImage, TOutputImage>
 /**
  * Destructor
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 RegionCompetitionImageFilter<TInputImage, TOutputImage>
 ::~RegionCompetitionImageFilter()
 {
@@ -84,7 +84,7 @@ RegionCompetitionImageFilter<TInputImage, TOutputImage>
 /**
  * Standard PrintSelf method.
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage, TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const
@@ -96,7 +96,7 @@ RegionCompetitionImageFilter<TInputImage, TOutputImage>
 /**
  * Set the input image containing initial labeled regions
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage, TOutputImage>
 ::SetInputLabels( const TOutputImage * inputLabeledImage )
@@ -105,7 +105,7 @@ RegionCompetitionImageFilter<TInputImage, TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::GenerateData()
@@ -120,7 +120,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::IterateFrontPropagations()
@@ -141,7 +141,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::AllocateOutputImageWorkingMemory()
@@ -161,7 +161,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::ComputeNumberOfInputLabels()
@@ -185,7 +185,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::AllocateFrontsWorkingMemory()
@@ -195,7 +195,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
   this->m_SeedsNewValues = new SeedNewValuesArrayType[ this->m_NumberOfLabels ];
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::InitializeNeighborhood()
@@ -206,7 +206,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::FindAllPixelsInTheBoundaryAndAddThemAsSeeds()
@@ -304,7 +304,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::VisitAllSeedsAndTransitionTheirState()
@@ -355,7 +355,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::PasteNewSeedValuesToOutputImage()
@@ -385,7 +385,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::SwapSeedArrays()
@@ -396,7 +396,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::ClearSecondSeedArray()
@@ -409,7 +409,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 bool
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::TestForAvailabilityAtCurrentPixel() const
@@ -418,7 +418,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::PutCurrentPixelNeighborsIntoSeedArray()
@@ -470,7 +470,7 @@ RegionCompetitionImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 RegionCompetitionImageFilter<TInputImage,TOutputImage>
 ::ComputeArrayOfNeighborhoodBufferOffsets()

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -70,7 +70,7 @@ namespace itk
  *
  * \ingroup LesionSizingToolkit
 */
-template <class PixelType = short int, unsigned int NDimension = 3>
+template <typename PixelType = short int, unsigned int NDimension = 3>
 class ITK_TEMPLATE_EXPORT VesselEnhancingDiffusion3DImageFilter :
     public ImageToImageFilter<Image<PixelType, NDimension> ,
                               Image<PixelType, NDimension> >

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
@@ -39,7 +39,7 @@ namespace itk
 {
 
 // constructor
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::VesselEnhancingDiffusion3DImageFilter():
     m_TimeStep(NumericTraits<Precision>::Zero),
@@ -54,7 +54,7 @@ VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 }
 
 // printself for debugging
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::PrintSelf(std::ostream &os, Indent indent) const
 {
@@ -74,7 +74,7 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
  os << indent << "DarkObjectLightBackground  : " << m_DarkObjectLightBackground << std::endl;
 }
 // singleiter
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::VED3DSingleIteration(typename PrecisionImageType::Pointer ci)
 {
@@ -413,7 +413,7 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 }
 
 // maxvesselresponse
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::MaxVesselResponse(const typename PrecisionImageType::Pointer im)
 {
@@ -542,7 +542,7 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 }
 
 // vesselnessfunction
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 typename VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>::Precision
 VesselEnhancingDiffusion3DImageFilter<PixelType,NDimension>
 ::VesselnessFunction3D( const Precision l1, const Precision l2, const Precision l3 )
@@ -578,7 +578,7 @@ VesselEnhancingDiffusion3DImageFilter<PixelType,NDimension>
 }
 
 // diffusiontensor
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::DiffusionTensor()
 {
@@ -645,7 +645,7 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 }
 
 // generatedata
-template <class PixelType, unsigned int NDimension>
+template <typename PixelType, unsigned int NDimension>
 void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
 ::GenerateData()
 {

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup RegionGrowingSegmentation 
  * \ingroup LesionSizingToolkit
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT VotingBinaryHoleFillFloodingImageFilter:
     public VotingBinaryImageFilter<TInputImage,TOutputImage>
 {

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
@@ -31,7 +31,7 @@ namespace itk
 /**
  * Constructor
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 ::VotingBinaryHoleFillFloodingImageFilter()
 {
@@ -52,7 +52,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 /**
  * Destructor
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 ::~VotingBinaryHoleFillFloodingImageFilter()
 {
@@ -64,7 +64,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 /**
  * Standard PrintSelf method.
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const
@@ -73,7 +73,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::GenerateData()
@@ -87,7 +87,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::IterateFrontPropagations()
@@ -115,7 +115,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::AllocateOutputImageWorkingMemory()
@@ -135,7 +135,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
  
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::InitializeNeighborhood()
@@ -144,7 +144,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::FindAllPixelsInTheBoundaryAndAddThemAsSeeds()
@@ -228,7 +228,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::VisitAllSeedsAndTransitionTheirState()
@@ -275,7 +275,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::PasteNewSeedValuesToOutputImage()
@@ -299,7 +299,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::SwapSeedArrays()
@@ -310,7 +310,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ClearSecondSeedArray()
@@ -320,7 +320,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 bool 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::TestForQuorumAtCurrentPixel() const
@@ -362,7 +362,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::PutCurrentPixelNeighborsIntoSeedArray()
@@ -414,7 +414,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 unsigned int
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::GetNeighborhoodSize() const
@@ -423,7 +423,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ComputeArrayOfNeighborhoodBufferOffsets()
@@ -465,7 +465,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
     }
 }
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void 
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ComputeBirthThreshold()


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.