### PR TITLE
STYLE: Prefer std::stoi and std::stod.

### DIFF
--- a/src/itkCannyEdgeDetectionImageFilter1.cxx
+++ b/src/itkCannyEdgeDetectionImageFilter1.cxx
@@ -29,6 +29,8 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkCannyEdgeDetectionImageFilter.h"
 
+#include <string>
+
 
 int main(int argc, char* argv[])
 {
@@ -51,17 +53,17 @@ int main(int argc, char* argv[])
 
   if( argc > 3 )
     {
-    sigma = atof( argv[3] );
+    sigma = std::stod( argv[3] );
     }
 
   if( argc > 4 )
     {
-    upperThreshold = atof( argv[4] );
+    upperThreshold = std::stod( argv[4] );
     }
 
   if( argc > 5 )
     {
-    lowerThreshold = atof( argv[5] );
+    lowerThreshold = std::stod( argv[5] );
     }
 
   using InputPixelType = signed short;

--- a/src/itkCannyEdgeDetectionImageFilter2.cxx
+++ b/src/itkCannyEdgeDetectionImageFilter2.cxx
@@ -29,6 +29,8 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkCannyEdgeDetectionRecursiveGaussianImageFilter.h"
 
+#include <string>
+
 
 int main(int argc, char* argv[])
 {
@@ -51,17 +53,17 @@ int main(int argc, char* argv[])
 
   if( argc > 3 )
     {
-    sigma = atof( argv[3] );
+    sigma = std::stod( argv[3] );
     }
 
   if( argc > 4 )
     {
-    upperThreshold = atof( argv[4] );
+    upperThreshold = std::stod( argv[4] );
     }
 
   if( argc > 5 )
     {
-    lowerThreshold = atof( argv[5] );
+    lowerThreshold = std::stod( argv[5] );
     }
 
   using InputPixelType = signed short;

--- a/src/itkGradientMagnitudeRecursiveGaussianImageFilter.cxx
+++ b/src/itkGradientMagnitudeRecursiveGaussianImageFilter.cxx
@@ -25,6 +25,8 @@
 #include "itkImageFileWriter.h"
 #include "itkGradientMagnitudeRecursiveGaussianImageFilter.h"
 
+#include <string>
+
 
 int main( int argc, char * argv[] )
 {
@@ -62,7 +64,7 @@ int main( int argc, char * argv[] )
 
   filter->SetInput( reader->GetOutput() );
 
-  const double sigma = atof( argv[3] );
+  const double sigma = std::stod( argv[3] );
 
   filter->SetSigma( sigma );
 

--- a/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
+++ b/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
@@ -31,6 +31,8 @@
 #include "itkEllipseSpatialObject.h"
 #include "itkImage.h"
 
+#include <string>
+
 
 int main( int argc, char ** argv )
 {
@@ -119,7 +121,7 @@ int main( int argc, char ** argv )
 
   InputImageType::IndexType originIndex;
 
-  const double radius = atof( argv[4] );
+  const double radius = std::stod( argv[4] );
 
   originIndex[0] = centralIndex[0] - radius / spacing[0];
   originIndex[1] = centralIndex[1] - radius / spacing[1];

--- a/src/itkImageReadRegionOfInterestWrite.cxx
+++ b/src/itkImageReadRegionOfInterestWrite.cxx
@@ -29,6 +29,8 @@
 #include "itkRegionOfInterestImageFilter.h"
 #include "itkImage.h"
 
+#include <string>
+
 
 int main( int argc, char ** argv )
 {
@@ -61,14 +63,14 @@ int main( int argc, char ** argv )
   FilterType::Pointer filter = FilterType::New();
 
   OutputImageType::IndexType start;
-  start[0] = atoi( argv[3] );
-  start[1] = atoi( argv[4] );
-  start[2] = atoi( argv[5] );
+  start[0] = std::stoi( argv[3] );
+  start[1] = std::atoi( argv[4] );
+  start[2] = std::atoi( argv[5] );
 
   OutputImageType::SizeType size;
-  size[0] = atoi( argv[6] );
-  size[1] = atoi( argv[7] );
-  size[2] = atoi( argv[8] );
+  size[0] = std::atoi( argv[6] );
+  size[1] = std::atoi( argv[7] );
+  size[2] = std::atoi( argv[8] );
 
 
   OutputImageType::RegionType desiredRegion;

--- a/src/itkLaplacianRecursiveGaussianImageFilter.cxx
+++ b/src/itkLaplacianRecursiveGaussianImageFilter.cxx
@@ -24,6 +24,8 @@
 #include "itkImageFileWriter.h"
 #include "itkLaplacianRecursiveGaussianImageFilter.h"
 
+#include <string>
+
 
 int main( int argc, char * argv[] )
 {
@@ -59,7 +61,7 @@ int main( int argc, char * argv[] )
 
   laplacian->SetInput( reader->GetOutput() );
 
-  const double sigma = atof( argv[3] );
+  const double sigma = std::stod( argv[3] );
 
   laplacian->SetSigma( sigma );
 

--- a/src/itkResampleVolumeToBeIsotropic.cxx
+++ b/src/itkResampleVolumeToBeIsotropic.cxx
@@ -29,6 +29,8 @@
 #include "itkBSplineInterpolateImageFunction.h"
 #include "itkWindowedSincInterpolateImageFunction.h"
 
+#include <string>
+
 
 int main( int argc, char * argv[] )
 {
@@ -100,7 +102,7 @@ int main( int argc, char * argv[] )
   LinearInterpolatorType::Pointer linearInterpolator = LinearInterpolatorType::New();
 
 
-  switch( atoi( argv[4] ) )
+  switch( std::stoi( argv[4] ) )
     {
     case 0:
       resampler->SetInterpolator( bsplineInterpolator );
@@ -127,7 +129,7 @@ int main( int argc, char * argv[] )
   ImageType::SpacingType outputSpacing;
 
   const double finalSpacing = (strcmp( argv[3], "-minspacing" ) == 0)
-                                        ? minSpacing : atof( argv[3] );
+                                        ? minSpacing : std::stod( argv[3] );
 
   outputSpacing[0] = finalSpacing;
   outputSpacing[1] = finalSpacing;


### PR DESCRIPTION
Prefer `std::stoi` to `atoi` and `std::stod` to `atof` due to the
reasons stated in these topics:
http://review.source.kitware.com/#/c/23738/
http://review.source.kitware.com/#/c/23743/
and
http://review.source.kitware.com/#/c/23745/
http://review.source.kitware.com/#/c/23746/