### PR TITLE
ENH: Improve code coverage.

### DIFF
--- a/test/LandmarkSpatialObjectWriterTest.cxx
+++ b/test/LandmarkSpatialObjectWriterTest.cxx
@@ -21,6 +21,8 @@
 #include "itkLandmarkSpatialObject.h"
 #include "itkSpatialObjectWriter.h"
 #include "itkSpatialObjectReader.h"
+#include "itkTestingMacros.h"
+
 
 int LandmarkSpatialObjectWriterTest( int itkNotUsed(argc), char * argv [] )
 {
@@ -33,7 +35,7 @@ int LandmarkSpatialObjectWriterTest( int itkNotUsed(argc), char * argv [] )
   using SpatialPointType = LandmarkType::SpatialObjectPointType;
   using PointListType = LandmarkType::PointListType;
 
-  PointListType     listOfPoints;
+  PointListType listOfPoints;
 
   SpatialPointType p;
 
@@ -63,9 +65,9 @@ int LandmarkSpatialObjectWriterTest( int itkNotUsed(argc), char * argv [] )
   writer->SetFileName( argv[1] );
   writer->SetBinaryPoints(false);
 
-  writer->Update();
-  
-  std::cout << " [TEST DONE]" << std::endl;
-  
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
+++ b/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [threshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [threshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,23 +50,16 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
 
   using BinaryThresholdFeatureGeneratorType = itk::BinaryThresholdFeatureGenerator< Dimension >;
   using SpatialObjectType = BinaryThresholdFeatureGeneratorType::SpatialObjectType;
 
-  BinaryThresholdFeatureGeneratorType::Pointer  featureGenerator = BinaryThresholdFeatureGeneratorType::New();
-  
-  std::cout << featureGenerator->GetNameOfClass() << std::endl;
-  featureGenerator->Print( std::cout );
+  BinaryThresholdFeatureGeneratorType::Pointer featureGenerator = BinaryThresholdFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    BinaryThresholdFeatureGenerator, FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -77,34 +72,14 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
   featureGenerator->SetInput( inputObject );
 
   double threshold  = 100.0;
-
   if( argc > 3 )
     {
-    threshold = atof( argv[3] );
+    threshold = std::stod( argv[3] );
     }
-
-  featureGenerator->SetThreshold( 0.0 );
-
   featureGenerator->SetThreshold( threshold );
-  if( featureGenerator->GetThreshold() != threshold )
-    {
-    std::cerr << "Error in Set/GetThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
+  TEST_SET_GET_VALUE( threshold, featureGenerator->GetThreshold() );
 
-  std::cout << featureGenerator->GetNameOfClass() << std::endl;
-  featureGenerator->Print( std::cout );
-
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
@@ -119,22 +94,9 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
@@ -22,14 +22,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [variance upperthreshold lowerthreshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [variance upperthreshold lowerthreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -50,21 +52,18 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using CannyEdgesDistanceAdvectionFieldFeatureGeneratorType = itk::CannyEdgesDistanceAdvectionFieldFeatureGenerator< Dimension >;
   using SpatialObjectType = CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::SpatialObjectType;
 
-  CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::New();
-  
+  CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::Pointer featureGenerator = CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    CannyEdgesDistanceAdvectionFieldFeatureGenerator,
+    FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -76,30 +75,35 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double upperThreshold =
+    itk::NumericTraits< CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::InternalPixelType >::max();
   if( argc > 4 )
     {
-    featureGenerator->SetUpperThreshold( atof( argv[4] ) );
+    upperThreshold = std::stod( argv[4] );
     }
+  featureGenerator->SetUpperThreshold( upperThreshold );
+  TEST_SET_GET_VALUE( upperThreshold, featureGenerator->GetUpperThreshold() );
 
+  double lowerThreshold =
+    itk::NumericTraits< CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::InternalPixelType >::min();
   if( argc > 5 )
     {
-    featureGenerator->SetLowerThreshold( atof( argv[4] ) );
+    lowerThreshold = std::stod( argv[5] );
     }
+  featureGenerator->SetLowerThreshold( lowerThreshold );
+  TEST_SET_GET_VALUE( lowerThreshold, featureGenerator->GetLowerThreshold() );
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -115,22 +119,9 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma upperthreshold lowerthreshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma upperthreshold lowerthreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -47,21 +49,17 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using CannyEdgesDistanceFeatureGeneratorType = itk::CannyEdgesDistanceFeatureGenerator< Dimension >;
   using SpatialObjectType = CannyEdgesDistanceFeatureGeneratorType::SpatialObjectType;
 
   CannyEdgesDistanceFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesDistanceFeatureGeneratorType::New();
-  
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    CannyEdgesDistanceFeatureGenerator,
+    FeatureGenerator );
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,63 +72,31 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
   featureGenerator->SetInput( inputObject );
 
   double sigma = 1.0;
-  double lowerthreshold = 100;
-  double upperthreshold = 200;
-
-  featureGenerator->SetSigma( 1.5 );
-  featureGenerator->SetUpperThreshold( 1000 );
-  featureGenerator->SetLowerThreshold(   50 );
-
-  double tolerance = 1e-4;
-
-  featureGenerator->SetSigma( sigma );
-
-  if( vnl_math_abs( featureGenerator->GetSigma() - sigma ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetSigma()" << std::endl;
-    std::cerr << "It should be " << sigma << std::endl;
-    std::cerr << "but got " << featureGenerator->GetSigma() << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetLowerThreshold( lowerthreshold );
-  if( vnl_math_abs( featureGenerator->GetLowerThreshold() - lowerthreshold ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetLowerThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetUpperThreshold( upperthreshold );
-  if( vnl_math_abs( featureGenerator->GetUpperThreshold() - upperthreshold ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetUpperThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double upperThreshold = 200;
   if( argc > 4 )
     {
-    featureGenerator->SetUpperThreshold( atof( argv[4] ) );
+    upperThreshold = std::stod( argv[4] );
     }
+  featureGenerator->SetUpperThreshold( upperThreshold );
+  TEST_SET_GET_VALUE( upperThreshold, featureGenerator->GetUpperThreshold() );
 
+  double lowerThreshold = 100;
   if( argc > 5 )
     {
-    featureGenerator->SetLowerThreshold( atof( argv[5] ) );
+    lowerThreshold = std::stod( argv[5] );
     }
+  featureGenerator->SetLowerThreshold( lowerThreshold );
+  TEST_SET_GET_VALUE( lowerThreshold, featureGenerator->GetLowerThreshold() );
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -146,22 +112,9 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkCannyEdgesFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma upperthreshold lowerthreshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma upperthreshold lowerthreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -47,21 +49,18 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
   using SpatialObjectType = CannyEdgesFeatureGeneratorType::SpatialObjectType;
 
-  CannyEdgesFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesFeatureGeneratorType::New();
-  
+  CannyEdgesFeatureGeneratorType::Pointer featureGenerator = CannyEdgesFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    CannyEdgesFeatureGenerator,
+    FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -73,64 +72,33 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
   double sigma = 1.0;
-  double lowerthreshold = 100;
-  double upperthreshold = 200;
-
-  featureGenerator->SetSigma( 1.5 );
-  featureGenerator->SetUpperThreshold( 1000 );
-  featureGenerator->SetLowerThreshold(   50 );
-
-  double tolerance = 1e-4;
-
-  featureGenerator->SetSigma( sigma );
-
-  if( vnl_math_abs( featureGenerator->GetSigma() - sigma ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetSigma()" << std::endl;
-    std::cerr << "It should be " << sigma << std::endl;
-    std::cerr << "but got " << featureGenerator->GetSigma() << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetLowerThreshold( lowerthreshold );
-  if( vnl_math_abs( featureGenerator->GetLowerThreshold() - lowerthreshold ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetLowerThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetUpperThreshold( upperthreshold );
-  if( vnl_math_abs( featureGenerator->GetUpperThreshold() - upperthreshold ) > tolerance )
-    {
-    std::cerr << "Error in Set/GetUpperThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double upperThreshold = 200;
   if( argc > 4 )
     {
-    featureGenerator->SetUpperThreshold( atof( argv[4] ) );
+    upperThreshold = std::stod( argv[4] );
     }
+  featureGenerator->SetUpperThreshold( upperThreshold );
+  TEST_SET_GET_VALUE( upperThreshold, featureGenerator->GetUpperThreshold() );
 
+  double lowerThreshold = 100;
   if( argc > 5 )
     {
-    featureGenerator->SetLowerThreshold( atof( argv[5] ) );
+    lowerThreshold = std::stod( argv[5] );
     }
+  featureGenerator->SetLowerThreshold( lowerThreshold );
+  TEST_SET_GET_VALUE( lowerThreshold, featureGenerator->GetLowerThreshold() );
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -146,22 +114,9 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
+++ b/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
@@ -20,14 +20,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkLandmarksReader.h"
+#include "itkTestingMacros.h"
+
 
 int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile featureImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile featureImage outputImage ";
     std::cerr << " [sigmaMultiplier] " << std::endl;
     return EXIT_FAILURE;
     }
@@ -54,19 +56,15 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 
   featureReader->SetFileName( argv[2] );
 
-  try 
-    {
-    featureReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureReader->Update() );
 
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    ConfidenceConnectedSegmentationModule,
+    RegionGrowingSegmentationModule );
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -78,17 +76,22 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 
   featureImage->DisconnectPipeline();
 
-  featureImage->Print( std::cout );
-
   featureObject->SetImage( featureImage );
 
   segmentationModule->SetFeature( featureObject );
   segmentationModule->SetInput( landmarksReader->GetOutput() );
 
-  const double sigmaMultiplier = (argc > 4) ? atof( argv[4] ) : 2.0;
-  segmentationModule->SetSigmaMultiplier( sigmaMultiplier );
 
-  segmentationModule->Update();
+  double sigmaMultiplier = 2.0;
+  if( argc > 4 )
+    {
+    sigmaMultiplier = std::stod( argv[4] );
+    }
+  segmentationModule->SetSigmaMultiplier( sigmaMultiplier );
+  TEST_SET_GET_VALUE( sigmaMultiplier, segmentationModule->GetSigmaMultiplier() );
+
+
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -103,35 +106,10 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  segmentationModule->Print( std::cout );
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
-  //
-  // Exerciser Get methods
-  //
-  segmentationModule->SetSigmaMultiplier( 0.0 );
-  if( segmentationModule->GetSigmaMultiplier() != 0.0 )
-    {
-    std::cerr << "Error in Set/GetSigmaMultiplier() " << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  segmentationModule->SetSigmaMultiplier( sigmaMultiplier );
-  if( segmentationModule->GetSigmaMultiplier() != sigmaMultiplier )
-    {
-    std::cerr << "Error in Set/GetSigmaMultiplier() " << std::endl;
-    return EXIT_FAILURE;
-    }
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkConnectedThresholdSegmentationModuleTest1.cxx
+++ b/test/itkConnectedThresholdSegmentationModuleTest1.cxx
@@ -20,14 +20,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkLandmarksReader.h"
+#include "itkTestingMacros.h"
+
 
 int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile featureImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile featureImage outputImage ";
     std::cerr << " [lowerThreshold upperThreshold] " << std::endl;
     return EXIT_FAILURE;
     }
@@ -44,29 +46,27 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
- 
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
+
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
 
   featureReader->SetFileName( argv[2] );
 
-  try 
-    {
-    featureReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureReader->Update() );
 
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    ConnectedThresholdSegmentationModule,
+    RegionGrowingSegmentationModule );
+
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -78,44 +78,30 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
 
   featureImage->DisconnectPipeline();
 
-  featureImage->Print( std::cout );
-
   featureObject->SetImage( featureImage );
 
   segmentationModule->SetFeature( featureObject );
   segmentationModule->SetInput( landmarksReader->GetOutput() );
 
-  double lowerThreshold = -700;
-  double upperThreshold = 1000;
 
+  double lowerThreshold = 700;
   if( argc > 4 )
     {
-    lowerThreshold = atof( argv[4] );
+    lowerThreshold = std::stod( argv[4] );
     }
+  segmentationModule->SetLowerThreshold( lowerThreshold );
+  TEST_SET_GET_VALUE( lowerThreshold, segmentationModule->GetLowerThreshold() );
 
+  double upperThreshold = 1000;
   if( argc > 5 )
     {
-    upperThreshold = atof( argv[5] );
+    upperThreshold = std::stod( argv[5] );
     }
-
-  segmentationModule->SetLowerThreshold( lowerThreshold );
   segmentationModule->SetUpperThreshold( upperThreshold );
+  TEST_SET_GET_VALUE( upperThreshold, segmentationModule->GetUpperThreshold() );
 
 
-  if( segmentationModule->GetLowerThreshold() != lowerThreshold )
-    {
-    std::cerr << "Error in Set/GetLowerThreshold() " << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  if( segmentationModule->GetUpperThreshold() != upperThreshold )
-    {
-    std::cerr << "Error in Set/GetUpperThreshold() " << std::endl;
-    return EXIT_FAILURE;
-    }
-
-
-  segmentationModule->Update();
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -130,21 +116,9 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
+++ b/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [(bright1/dark:0) sigma sheetness bloobiness noise ]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [(bright1/dark:0) sigma sheetness bloobiness noise ]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,21 +50,18 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using DescoteauxSheetnessFeatureGeneratorType = itk::DescoteauxSheetnessFeatureGenerator< Dimension >;
   using SpatialObjectType = DescoteauxSheetnessFeatureGeneratorType::SpatialObjectType;
 
-  DescoteauxSheetnessFeatureGeneratorType::Pointer  featureGenerator = DescoteauxSheetnessFeatureGeneratorType::New();
-  
+  DescoteauxSheetnessFeatureGeneratorType::Pointer featureGenerator = DescoteauxSheetnessFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    DescoteauxSheetnessFeatureGenerator,
+    FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,76 +73,48 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
-  //
-  // Exercise brightness methods
-  //
-  featureGenerator->DetectBrightSheetsOff();
-  featureGenerator->SetDetectBrightSheets( true );
-  if( !featureGenerator->GetDetectBrightSheets() )
-    {
-    std::cerr << "Error in Set/GetDetectBrightSheets()" << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  featureGenerator->SetDetectBrightSheets( false );
-  if( featureGenerator->GetDetectBrightSheets() )
-    {
-    std::cerr << "Error in Set/GetDetectBrightSheets()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->DetectBrightSheetsOn();
-  if( !featureGenerator->GetDetectBrightSheets() )
-    {
-    std::cerr << "Error in DetectBrightSheetsOn()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->DetectBrightSheetsOff();
-  if( featureGenerator->GetDetectBrightSheets() )
-    {
-    std::cerr << "Error in DetectBrightSheetsOff()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  // Finally leave it On
-  featureGenerator->DetectBrightSheetsOn();
-
-
+  bool detectBrightSheets = true;
   if( argc > 3 )
     {
-    featureGenerator->SetDetectBrightSheets( atoi( argv[3] ) );
+    detectBrightSheets = std::stoi( argv[3] );
     }
+  TEST_SET_GET_BOOLEAN( featureGenerator, DetectBrightSheets, detectBrightSheets );
 
+  double sigma = 1.0;
   if( argc > 4 )
     {
-    featureGenerator->SetSigma( atof( argv[4] ) );
+    sigma = std::stod( argv[4] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double sheetnessNormalization = 0.5;
   if( argc > 5 )
     {
-    featureGenerator->SetSheetnessNormalization( atof( argv[5] ) );
+    sheetnessNormalization = std::stod( argv[5] );
     }
+  featureGenerator->SetSheetnessNormalization( sheetnessNormalization );
+  TEST_SET_GET_VALUE( sheetnessNormalization, featureGenerator->GetSheetnessNormalization() );
 
+  double bloobinessNormalization = 2.0;
   if( argc > 6 )
     {
-    featureGenerator->SetBloobinessNormalization( atof( argv[6] ) );
+    bloobinessNormalization = std::stod( argv[6] );
     }
+  featureGenerator->SetBloobinessNormalization( bloobinessNormalization );
+  TEST_SET_GET_VALUE( bloobinessNormalization, featureGenerator->GetBloobinessNormalization() );
 
+  double noiseNormalization = 1.0;
   if( argc > 7 )
     {
-    featureGenerator->SetNoiseNormalization( atof( argv[7] ) );
+    noiseNormalization = std::stod( argv[7] );
     }
+  featureGenerator->SetNoiseNormalization( noiseNormalization );
+  TEST_SET_GET_VALUE( noiseNormalization, featureGenerator->GetNoiseNormalization() );
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -158,21 +129,9 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( outputImage );
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkDescoteauxSheetnessImageFilterTest2.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest2.cxx
@@ -18,16 +18,20 @@
 #include "itkSymmetricEigenAnalysisImageFilter.h"
 #include "itkImage.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
 {
-
   if( argc < 2 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " outputImage [(bright1/dark:0) sigma sheetness bloobiness noise]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " outputImage [(bright1/dark:0) sigma sheetness bloobiness noise]" << std::endl;
     return EXIT_FAILURE;
     }
+
+  int testStatus = EXIT_SUCCESS;
 
   constexpr unsigned int Dimension = 3;
 
@@ -44,7 +48,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   using EigenValueArrayType = itk::FixedArray< double, HessianPixelType::Dimension >;
   using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter< 
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
     HessianImageType, EigenValueImageType >;
 
   using WriterType = itk::ImageFileWriter< OutputImageType >;
@@ -59,7 +63,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   spacing[0] = 0.5;
   spacing[1] = 0.5;
   spacing[2] = 0.5;
-  
+
   inputImage->SetSpacing( spacing );
 
 
@@ -101,10 +105,9 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
 
   InputImageType::IndexType firstIndex;
   firstIndex.Fill(0);
-  std::cout << "First pixel value = " << inputImage->GetPixel(firstIndex) << std::endl; 
-  //
-  // Populate the inputImage with a bright XY plane  
-  //
+  std::cout << "First pixel value = " << inputImage->GetPixel(firstIndex) << std::endl;
+
+  // Populate the inputImage with a bright XY plane
   while( !itr.IsAtEnd() )
     {
     itr.Set( brightValue );
@@ -115,64 +118,73 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   using FilterType = itk::DescoteauxSheetnessImageFilter< EigenValueImageType, OutputImageType >;
 
   FilterType::Pointer sheetnessFilter = FilterType::New();
-  
+
+  EXERCISE_BASIC_OBJECT_METHODS( sheetnessFilter,
+    DescoteauxSheetnessImageFilter,
+    UnaryFunctorImageFilter );
+
+
   hessian->SetInput( inputImage );
   eigen->SetInput( hessian->GetOutput() );
   sheetnessFilter->SetInput( eigen->GetOutput() );
 
-  sheetnessFilter->SetDetectBrightSheets(true);
 
+  bool detectBrightSheets = true;
   if( argc > 2 )
     {
-    sheetnessFilter->SetDetectBrightSheets( atoi( argv[2] ) );
+    detectBrightSheets = std::stoi( argv[2] );
     }
+  sheetnessFilter->SetDetectBrightSheets( detectBrightSheets );
+  //TEST_SET_GET_BOOLEAN( sheetnessFilter, DetectBrightSheets, detectBrightSheets );
 
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    hessian->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  hessian->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, hessian->GetSigma() );
 
+  double sheetnessNormalization = 0.5;
   if( argc > 4 )
     {
-    sheetnessFilter->SetSheetnessNormalization( atof( argv[4] ) );
+    sheetnessNormalization = std::stod( argv[4] );
     }
+  sheetnessFilter->SetSheetnessNormalization( sheetnessNormalization );
+  //TEST_SET_GET_VALUE( sheetnessNormalization, sheetnessFilter->GetSheetnessNormalization() );
 
+  double bloobinessNormalization = 2.0;
   if( argc > 5 )
     {
-    sheetnessFilter->SetBloobinessNormalization( atof( argv[5] ) );
+    bloobinessNormalization = std::stod( argv[5] );
     }
+  sheetnessFilter->SetBloobinessNormalization( bloobinessNormalization );
+  //TEST_SET_GET_VALUE( bloobinessNormalization, sheetnessFilter->GetBloobinessNormalization() );
 
+  double noiseNormalization = 1.0;
   if( argc > 6 )
     {
-    sheetnessFilter->SetNoiseNormalization( atof( argv[6] ) );
+    noiseNormalization = std::stod( argv[6] );
     }
+  sheetnessFilter->SetNoiseNormalization( noiseNormalization );
+  //TEST_SET_GET_VALUE( noiseNormalization, sheetnessFilter->GetNoiseNormalization() );
 
 
   eigen->SetDimension( Dimension );
+
+
+  TRY_EXPECT_NO_EXCEPTION( sheetnessFilter->Update() );
+
 
   WriterType::Pointer writer = WriterType::New();
 
   writer->SetFileName( argv[1] );
   writer->SetInput( sheetnessFilter->GetOutput() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  std::cout << "Name Of Class = " << sheetnessFilter->GetNameOfClass() << std::endl;
-
-  sheetnessFilter->Print( std::cout );
 
   OutputImageType::ConstPointer outputImage = sheetnessFilter->GetOutput();
-
-  std::cout << "Output Image = " << std::endl;
-  outputImage->Print( std::cout );
 
   using ConstIterator = itk::ImageRegionConstIterator< OutputImageType >;
 
@@ -181,8 +193,6 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
 
   citr.GoToBegin();
   iitr.GoToBegin();
-
-  bool failed = false;
 
   InputPixelType meanValue = ( brightValue + darkValue ) / 2.0;
 
@@ -197,20 +207,22 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
       {
       if( citr.Get() < 0.9 )
         {
+        std::cerr << "Test failed!" << std::endl;
         std::cerr << "Detection bright failure at index " << citr.GetIndex();
         std::cerr << " Input = " << iitr.Get();
         std::cerr << " Sheetness = " << citr.Get() << std::endl;
-        failed = true;
+        testStatus = EXIT_FAILURE;
         }
       }
     else
       {
       if( citr.Get() > 0.1 )
         {
+        std::cerr << "Test failed!" << std::endl;
         std::cerr << "Detection dark failure at index " << citr.GetIndex();
         std::cerr << " Input = " << iitr.Get();
         std::cerr << " Sheetness = " << citr.Get() << std::endl;
-        failed = true;
+        testStatus = EXIT_FAILURE;
         }
       }
 
@@ -218,11 +230,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
     ++iitr;
     }
 
-  if( failed )
-    {
-    std::cerr << "The output values didn't match expected values" << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  return EXIT_SUCCESS;
+  std::cout << "Test finished." << std::endl;
+  return testStatus;
 }

--- a/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
+++ b/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma sheetness bloobiness noise ]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma sheetness bloobiness noise ]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,21 +50,17 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using FrangiTubularnessFeatureGeneratorType = itk::FrangiTubularnessFeatureGenerator< Dimension >;
   using SpatialObjectType = FrangiTubularnessFeatureGeneratorType::SpatialObjectType;
 
-  FrangiTubularnessFeatureGeneratorType::Pointer  featureGenerator = FrangiTubularnessFeatureGeneratorType::New();
-  
+  FrangiTubularnessFeatureGeneratorType::Pointer featureGenerator = FrangiTubularnessFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    FrangiTubularnessFeatureGenerator, FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,36 +72,41 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double sheetnessNormalization = 0.5;
   if( argc > 4 )
     {
-    featureGenerator->SetSheetnessNormalization( atof( argv[4] ) );
+    sheetnessNormalization = std::stod( argv[4] );
     }
+  featureGenerator->SetSheetnessNormalization( sheetnessNormalization );
+  TEST_SET_GET_VALUE( sheetnessNormalization, featureGenerator->GetSheetnessNormalization() );
 
+  double bloobinessNormalization = 2.0;
   if( argc > 5 )
     {
-    featureGenerator->SetBloobinessNormalization( atof( argv[5] ) );
+    bloobinessNormalization = std::stod( argv[5] );
     }
+  featureGenerator->SetBloobinessNormalization( bloobinessNormalization );
+  TEST_SET_GET_VALUE( bloobinessNormalization, featureGenerator->GetBloobinessNormalization() );
 
+  double noiseNormalization = 1.0;
   if( argc > 6 )
     {
-    featureGenerator->SetNoiseNormalization( atof( argv[6] ) );
+    noiseNormalization = std::stod( argv[6] );
     }
+  featureGenerator->SetNoiseNormalization( noiseNormalization );
+  TEST_SET_GET_VALUE( noiseNormalization, featureGenerator->GetNoiseNormalization() );
 
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -118,22 +121,9 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( outputImage );
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
@@ -19,14 +19,17 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage featureImage outputImage [advectionScaling] [curvatureScaling] [propagationScaling] [maxIterations]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage featureImage outputImage";
+    std::cerr << " [advectionScaling] [curvatureScaling] [propagationScaling] [maxIterations]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -35,8 +38,13 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
 
   using SegmentationModuleType = itk::GeodesicActiveContourLevelSetSegmentationModule< Dimension >;
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    GeodesicActiveContourLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+
   using InputImageType = SegmentationModuleType::InputImageType;
   using FeatureImageType = SegmentationModuleType::FeatureImageType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -49,18 +57,13 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
 
   inputReader->SetFileName( argv[1] );
+
+  TRY_EXPECT_NO_EXCEPTION( inputReader->Update() );
+
+
   featureReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputReader->Update();
-    featureReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureReader->Update() );
 
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -75,32 +78,42 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
 
   segmentationModule->SetInput( inputObject );
   segmentationModule->SetFeature( featureObject );
-   
+
+
+  double advectionScaling = 1.0;
   if (argc > 4)
     {
-    segmentationModule->SetAdvectionScaling( atof(argv[4]) );
-    std::cout << "Setting advection scaling to " << atof(argv[4]) << std::endl;
+    advectionScaling = std::stod( argv[4] );
     }
+  segmentationModule->SetAdvectionScaling( advectionScaling );
+  TEST_SET_GET_VALUE( advectionScaling, segmentationModule->GetAdvectionScaling() );
 
+  double curvatureScaling = 1.0;
   if (argc > 5)
     {
-    segmentationModule->SetCurvatureScaling( atof(argv[5]) );
-    std::cout << "Setting curvature scaling to " << atof(argv[5]) << std::endl;
+    curvatureScaling = std::stod( argv[5] );
     }
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
 
+  double propagationScaling = 100.0;
   if (argc > 6)
     {
-    segmentationModule->SetPropagationScaling( atof(argv[6]) );
-    std::cout << "Setting propagation scaling to " << atof(argv[6]) << std::endl;
+    propagationScaling = std::stod( argv[6] );
     }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
 
+  unsigned int maximumNumberOfIterations = 100;
   if (argc > 7)
     {
-    segmentationModule->SetMaximumNumberOfIterations( atof(argv[7]) );
-    std::cout << "Setting maximum iterations to " << atof(argv[7]) << std::endl;
+    maximumNumberOfIterations = std::stod(argv[7]);
     }
-  
-  segmentationModule->Update();
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
+
+
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -115,20 +128,9 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkGradientMagnitudeSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkGradientMagnitudeSigmoidFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkGradientMagnitudeSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma alpha beta]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr  << " inputImage outputImage [sigma alpha beta]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,20 +50,16 @@ int itkGradientMagnitudeSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using GradientMagnitudeSigmoidFeatureGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator< Dimension >;
   using SpatialObjectType = GradientMagnitudeSigmoidFeatureGeneratorType::SpatialObjectType;
 
-  GradientMagnitudeSigmoidFeatureGeneratorType::Pointer  featureGenerator = GradientMagnitudeSigmoidFeatureGeneratorType::New();
+  GradientMagnitudeSigmoidFeatureGeneratorType::Pointer featureGenerator = GradientMagnitudeSigmoidFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    GradientMagnitudeSigmoidFeatureGenerator, FeatureGenerator );
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -74,31 +72,33 @@ int itkGradientMagnitudeSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double alpha = -1.0;
   if( argc > 4 )
     {
-    featureGenerator->SetAlpha( atof( argv[4] ) );
+    alpha = std::stod( argv[4] );
     }
+  featureGenerator->SetAlpha( alpha );
+  TEST_SET_GET_VALUE( alpha, featureGenerator->GetAlpha() );
 
+  double beta = 128;
   if( argc > 5 )
     {
-    featureGenerator->SetBeta( atof( argv[5] ) );
+    beta = std::stod( argv[5] );
     }
+  featureGenerator->SetBeta( beta );
+  TEST_SET_GET_VALUE( beta, featureGenerator->GetBeta() );
 
 
-  try
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -113,22 +113,9 @@ int itkGradientMagnitudeSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( outputImage );
 
-
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
@@ -19,13 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itksys/SystemTools.hxx"
+#include "itkTestingMacros.h"
+
 
 int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] )
 {
   if( argc < 6 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputSegmentationImage MethodID DatasetID ExpectedVolume ouputTextFile " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputSegmentationImage MethodID DatasetID ExpectedVolume ouputTextFile " << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -39,15 +42,8 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName( argv[1] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
+
 
   InputImageType::Pointer inputImage = inputImageReader->GetOutput();
   inputImage->DisconnectPipeline();
@@ -55,7 +51,12 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
   InputSpatialObjectType::Pointer inputImageSpatialObject = InputSpatialObjectType::New();
   inputImageSpatialObject->SetImage( inputImage );
 
-  VolumeEstimatorType::Pointer  volumeEstimator = VolumeEstimatorType::New();
+  VolumeEstimatorType::Pointer volumeEstimator = VolumeEstimatorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( volumeEstimator,
+    GrayscaleImageSegmentationVolumeEstimator, SegmentationVolumeEstimator );
+
+
   volumeEstimator->SetInput( inputImageSpatialObject );
   volumeEstimator->Update();
 
@@ -70,7 +71,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
 
   const std::string segmentationMethodID = argv[2];
   const std::string datasetID = argv[3];
-  const double  expectedVolume = atof( argv[4] );
+  const double expectedVolume = std::stod( argv[4] );
   const std::string outpuFileName = argv[5];
 
   const double volumeDifference = volume - expectedVolume;
@@ -106,5 +107,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
 
   ouputFile.close();
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkIsotropicResamplerTest1.cxx
+++ b/test/itkIsotropicResamplerTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkIsotropicResamplerTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage " << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage " << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,20 +50,16 @@ int itkIsotropicResamplerTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using ResampleFilterType = itk::IsotropicResampler< Dimension >;
   using SpatialObjectType = ResampleFilterType::SpatialObjectType;
 
-  ResampleFilterType::Pointer  resampler = ResampleFilterType::New();
+  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( resampler,
+    IsotropicResampler, ProcessObject );
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -74,15 +72,7 @@ int itkIsotropicResamplerTest1( int argc, char * argv [] )
 
   resampler->SetInput( inputObject );
 
-  try
-    {
-    resampler->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( resampler->Update() );
 
 
   SpatialObjectType::ConstPointer resampledImage = resampler->GetOutput();
@@ -98,20 +88,9 @@ int itkIsotropicResamplerTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  std::cout << "Name Of Class = " << resampler->GetNameOfClass() << std::endl;
-
-  resampler->Print( std::cout );
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLandmarksReaderTest1.cxx
+++ b/test/itkLandmarksReaderTest1.cxx
@@ -16,14 +16,16 @@
 #include "itkLandmarksReader.h"
 #include "itkSpatialObject.h"
 #include "itkSpatialObjectReader.h"
+#include "itkTestingMacros.h"
+
 
 int itkLandmarksReaderTest1( int argc, char * argv [] )
 {
-
   if( argc < 2 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile ";
     return EXIT_FAILURE;
     }
 
@@ -52,7 +54,8 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  landmarksReader->Update();
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
 
   InputSpatialObjectType::ConstPointer landmarkSpatialObject1 = landmarksReader->GetOutput();
 
@@ -63,6 +66,9 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
 
   SpatialObjectReaderType::Pointer landmarkPointsReader = SpatialObjectReaderType::New();
 
+  EXERCISE_BASIC_OBJECT_METHODS( landmarkPointsReader, SpatialObjectReader,
+    Object );
+
   landmarkPointsReader->SetFileName( argv[1] );
   landmarkPointsReader->Update();
 
@@ -70,7 +76,8 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
 
   if( !scene )
     {
-    std::cerr << "No Scene : [FAILED]" << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "No Scene." << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -103,26 +110,30 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
 
   if( numberOfPoints1 != numberOfPoints2 )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Number of points is not consistent between two read methods" << std::endl;
+    std::cerr << "Error in GetNumberOfPoints()" << std::endl;
+    std::cerr << "Expected value " << numberOfPoints1 << std::endl;
+    std::cerr << " differs from " << numberOfPoints2 << std::endl;
     return EXIT_FAILURE;
     }
 
   const PointListType & points1 = landmarkSpatialObject1->GetPoints();
   const PointListType & points2 = landmarkSpatialObject2->GetPoints();
 
-  for( unsigned int i=0; i < numberOfPoints1; i++ )
+  for( unsigned int i = 0; i < numberOfPoints1; ++i )
     {
     if( points1[i].GetPosition() != points2[i].GetPosition() )
       {
+      std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error : point " << i << " has different positions" << std::endl;
-      std::cerr << "Expected position " << points2[i].GetPosition() << std::endl;
-      std::cerr << "Received position " << points1[i].GetPosition() << std::endl;
+      std::cerr << "Expected value " << points2[i].GetPosition() << std::endl;
+      std::cerr << " differs from" << points1[i].GetPosition() << std::endl;
       return EXIT_FAILURE;
       }
     }
 
 
-  landmarkPointsReader->Print( std::cout );
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest1.cxx
+++ b/test/itkLesionSegmentationMethodTest1.cxx
@@ -18,6 +18,8 @@
 #include "itkImage.h"
 #include "itkSpatialObject.h"
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
+
 
 int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
 {
@@ -26,7 +28,11 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  segmentationMethod = MethodType::New();
-  
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationMethod, LesionSegmentationMethod,
+    ProcessObject );
+
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -38,6 +44,7 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
 
   if( regionOfInterestReturned != regionOfInterest.GetPointer() )
     {
+    std::cerr << "Test failed! " << std::endl;
     std::cerr << "Error in Set/GetRegionOfInterest() " << std::endl;
     return EXIT_FAILURE;
     }
@@ -45,12 +52,13 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
   ImageMaskSpatialObjectType::Pointer initialSegmentation = ImageMaskSpatialObjectType::New();
 
   segmentationMethod->SetInitialSegmentation( initialSegmentation );
-  
+
   const MethodType::SpatialObjectType * initialSegmentationReturned =
     segmentationMethod->GetInitialSegmentation();
 
   if( initialSegmentationReturned != initialSegmentation.GetPointer() )
     {
+    std::cerr << "Test failed! " << std::endl;
     std::cerr << "Error in Set/GetInitialSegmentation() " << std::endl;
     return EXIT_FAILURE;
     }
@@ -61,20 +69,9 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
 
   segmentationMethod->AddFeatureGenerator( featureGenerator );
 
-  try
-    {
-    segmentationMethod->Update();
-    std::cerr << "Failed to catch expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( segmentationMethod->Update() );
 
-  segmentationMethod->Print( std::cout );
 
-  
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest2.cxx
+++ b/test/itkLesionSegmentationMethodTest2.cxx
@@ -22,6 +22,8 @@
 #include "itkGradientMagnitudeSigmoidFeatureGenerator.h"
 #include "itkSatoLocalStructureFeatureGenerator.h"
 #include "itkSatoVesselnessFeatureGenerator.h"
+#include "itkTestingMacros.h"
+
 
 int itkLesionSegmentationMethodTest2( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
 {
@@ -29,8 +31,11 @@ int itkLesionSegmentationMethodTest2( int itkNotUsed(argc), char * itkNotUsed(ar
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
-  MethodType::Pointer  segmentationMethod = MethodType::New();
-  
+  MethodType::Pointer segmentationMethod = MethodType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS(  segmentationMethod, LesionSegmentationMethod,
+    LightObject );
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -63,19 +68,9 @@ int itkLesionSegmentationMethodTest2( int itkNotUsed(argc), char * itkNotUsed(ar
   segmentationMethod->AddFeatureGenerator( localStructureGenerator );
   segmentationMethod->AddFeatureGenerator( gradientMagnitudeSigmoidGenerator );
 
-  try
-    {
-    segmentationMethod->Update();
-    std::cerr << "Failed to catch expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( segmentationMethod->Update() );
 
-  segmentationMethod->Print( std::cout );
-  
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest4.cxx
+++ b/test/itkLesionSegmentationMethodTest4.cxx
@@ -29,16 +29,19 @@
 #include "itkSigmoidFeatureGenerator.h"
 #include "itkFastMarchingSegmentationModule.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
+
 
 int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tlandmarksFile\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\tstopping time for fast marching";
-    std::cerr << "\n\tdistance from seeds for fast marching" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage";
+    std::cerr << " stoppingValue";
+    std::cerr << " distanceFromSeeds" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -53,15 +56,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
@@ -84,7 +79,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
  
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
-  CannyEdgesFeatureGeneratorType::Pointer  cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
+  CannyEdgesFeatureGeneratorType::Pointer cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
  
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
@@ -129,26 +124,39 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   using SegmentationModuleType = itk::FastMarchingSegmentationModule< Dimension >;
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
 
-  const double stoppingTime = (argc > 4) ? atof( argv[4] ) : 10.0;
-  const double distanceFromSeeds = (argc > 5) ? atof( argv[5] ) : 5.0;
-
+  double stoppingTime = 10.0;
+  if( argc > 4 )
+    {
+    stoppingTime = std::stod( argv[4] );
+    }
   segmentationModule->SetStoppingValue( stoppingTime );
+  TEST_SET_GET_VALUE( stoppingTime, segmentationModule->GetStoppingValue() );
+
+  double distanceFromSeeds = 5.0;
+  if( argc > 5 )
+    {
+    distanceFromSeeds = std::stod( argv[5] );
+    }
   segmentationModule->SetDistanceFromSeeds( distanceFromSeeds );
+  TEST_SET_GET_VALUE( distanceFromSeeds, segmentationModule->GetDistanceFromSeeds() );
+
 
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
 
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
 
-  lesionSegmentationMethod->Update();
+  TRY_EXPECT_NO_EXCEPTION( lesionSegmentationMethod->Update() );
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -167,20 +175,13 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
   segmentationModule->Print( std::cout );
 
   std::cout << "Name of class " << segmentationModule->GetNameOfClass() << std::endl;
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest5.cxx
+++ b/test/itkLesionSegmentationMethodTest5.cxx
@@ -29,18 +29,20 @@
 #include "itkGradientMagnitudeSigmoidFeatureGenerator.h"
 #include "itkShapeDetectionLevelSetSegmentationModule.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
+
 
 int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tinputSegmentation\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\t[RMSErrorForShapeDetection]"
-              << "\n\t[IterationsForShapeDetection]"
-              << "\n\t[CurvatureScalingForShapeDetection]"
-              << "\n\t[PropagationScalingForShapeDetection]"
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputSegmentation inputImage outputImage ";
+    std::cerr << " [RMSErrorForShapeDetection]"
+              << " [IterationsForShapeDetection]"
+              << " [CurvatureScalingForShapeDetection]"
+              << " [PropagationScalingForShapeDetection]"
               << std::endl;
     return EXIT_FAILURE;
     }
@@ -56,21 +58,13 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -85,7 +79,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using GradientMagnitudeSigmoidGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator< Dimension >;
   GradientMagnitudeSigmoidGeneratorType::Pointer gradientMagnitudeSigmoidGenerator = 
     GradientMagnitudeSigmoidGeneratorType::New();
@@ -121,10 +115,10 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   gradientMagnitudeSigmoidGenerator->SetSigma( 1.0 );
   gradientMagnitudeSigmoidGenerator->SetAlpha( -0.1 );
   gradientMagnitudeSigmoidGenerator->SetBeta( 150.0 );
@@ -132,26 +126,46 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   using SegmentationModuleType = itk::ShapeDetectionLevelSetSegmentationModule< Dimension >;
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
 
-  if (argc > 4)
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    ShapeDetectionLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+
+  double maximumRMSError = 0.0002;
+  if( argc > 4 )
     {
-    segmentationModule->SetMaximumRMSError( atof( argv[4]) );
+    maximumRMSError = std::stod( argv[4] );
     }
-  if (argc > 5)
+  segmentationModule->SetMaximumRMSError( maximumRMSError );
+  TEST_SET_GET_VALUE( maximumRMSError, segmentationModule->GetMaximumRMSError() );
+
+  unsigned int maximumNumberOfIterations = 300;
+  if( argc > 5 )
     {
-    segmentationModule->SetMaximumNumberOfIterations( atoi( argv[5]) );
+    maximumNumberOfIterations = std::stoi( argv[5] );
     }
-  if (argc > 6)
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
+
+  double curvatureScaling = 1.0;
+  if( argc > 6 )
     {
-    segmentationModule->SetCurvatureScaling( atof( argv[6]) );
+    curvatureScaling = std::stod( argv[6] );
     }
-  if (argc > 7)
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
+
+  double propagationScaling = 500.0;
+  if( argc > 7 )
     {
-    segmentationModule->SetPropagationScaling( atof( argv[7]) );
+    propagationScaling = std::stod( argv[7] );
     }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
 
 
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
- 
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using InputSegmentationType = SegmentationModuleType::InputImageType;
 
@@ -161,15 +175,8 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   inputSegmentationReader->SetFileName( argv[1] );
 
-  try 
-    {
-    inputSegmentationReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputSegmentationReader->Update() );
+
 
   InputSegmentationType::Pointer inputSegmentation = inputSegmentationReader->GetOutput();
 
@@ -181,9 +188,9 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   lesionSegmentationMethod->SetInitialSegmentation( inputImageSpatialObject );
 
-  lesionSegmentationMethod->Update();
+  TRY_EXPECT_NO_EXCEPTION( lesionSegmentationMethod->Update() );
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -202,20 +209,9 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Name of class " << segmentationModule->GetNameOfClass() << std::endl;
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest7.cxx
+++ b/test/itkLesionSegmentationMethodTest7.cxx
@@ -28,21 +28,24 @@
 #include "itkSigmoidFeatureGenerator.h"
 #include "itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
 
+
+// Applies fast marhching followed by segmentation using geodesic active contours.
 int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Applies fast marhching followed by segmentation using geodesic active contours. Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tlandmarksFile\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\t[RMSErrorForGeodesicActiveContour]"
-              << "\n\t[IterationsForGeodesicActiveContour]"
-              << "\n\t[CurvatureScalingForGeodesicActiveContour]"
-              << "\n\t[PropagationScalingForGeodesicActiveContour]"
-              << "\n\t[AdvectionScalingForGeodesicActiveContour]";
-    std::cerr << "\n\t[stopping time for fast marching]";
-    std::cerr << "\n\t[distance from seeds for fast marching]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage";
+    std::cerr << " [RMSErrorForGeodesicActiveContour]"
+              << " [IterationsForGeodesicActiveContour]"
+              << " [CurvatureScalingForGeodesicActiveContour]"
+              << " [PropagationScalingForGeodesicActiveContour]"
+              << " [AdvectionScalingForGeodesicActiveContour]";
+    std::cerr << " [stoppingTime]";
+    std::cerr << " [distanceFromSeeds]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -57,15 +60,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
@@ -115,27 +110,85 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   sigmoidGenerator->SetBeta( -200.0 );
  
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule< Dimension >;
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  segmentationModule->SetMaximumRMSError( argc > 4 ? atof(argv[4]) : 0.0002 );
-  segmentationModule->SetMaximumNumberOfIterations( argc > 5 ? atoi(argv[5]) : 300 );
-  segmentationModule->SetCurvatureScaling( argc > 6 ? atof(argv[6]) : 1.0 );
-  segmentationModule->SetPropagationScaling( argc > 7 ? atof(argv[7]) : 500.0 );
-  segmentationModule->SetAdvectionScaling( argc > 8 ? atof(argv[8]) : 0.0 );
-  segmentationModule->SetStoppingValue( argc > 9 ? atof(argv[9]) : 5.0 );
-  segmentationModule->SetDistanceFromSeeds( argc > 10 ? atof(argv[10]) : 2.0 );
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+
+  double maximumRMSError = 0.0002;
+  if( argc > 4 )
+    {
+    maximumRMSError = std::stod( argv[4] );
+    }
+  segmentationModule->SetMaximumRMSError( maximumRMSError );
+  TEST_SET_GET_VALUE( maximumRMSError, segmentationModule->GetMaximumRMSError() );
+
+  unsigned int maximumNumberOfIterations = 300;
+  if( argc > 5 )
+    {
+    maximumNumberOfIterations = std::stoi( argv[5] );
+    }
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
+
+  double curvatureScaling = 1.0;
+  if( argc > 6 )
+    {
+    curvatureScaling = std::stod( argv[6] );
+    }
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
+
+  double propagationScaling = 500.0;
+  if( argc > 7 )
+    {
+    propagationScaling = std::stod( argv[7] );
+    }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
+
+  double advectionScaling = 0.0;
+  if( argc > 8 )
+    {
+    advectionScaling = std::stod( argv[8] );
+    }
+  segmentationModule->SetAdvectionScaling( advectionScaling );
+  TEST_SET_GET_VALUE( advectionScaling, segmentationModule->GetAdvectionScaling() );
+
+  double stoppingValue = 5.0;
+  if( argc > 9 )
+    {
+    stoppingValue = std::stod( argv[9] );
+    }
+  segmentationModule->SetStoppingValue( stoppingValue );
+  TEST_SET_GET_VALUE( stoppingValue, segmentationModule->GetStoppingValue() );
+
+  double distanceFromSeeds = 2.0;
+  if( argc > 10 )
+    {
+    distanceFromSeeds = std::stod( argv[10] );
+    }
+  segmentationModule->SetDistanceFromSeeds( distanceFromSeeds );
+  TEST_SET_GET_VALUE( distanceFromSeeds, segmentationModule->GetDistanceFromSeeds() );
+
+
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
 
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
-  lesionSegmentationMethod->Update();
+  TRY_EXPECT_NO_EXCEPTION( lesionSegmentationMethod->Update() );
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -152,34 +205,17 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  // 
+  //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
-    {
-    lesionSegmentationMethod->Update();
-    std::cerr << "Failure to throw expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception " << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( lesionSegmentationMethod->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest8.cxx
+++ b/test/itkLesionSegmentationMethodTest8.cxx
@@ -29,24 +29,27 @@
 #include "itkSigmoidFeatureGenerator.h"
 #include "itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
 
+
+// Applies fast marhching followed by segmentation using geodesic active contours.
 int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Applies fast marhching followed by segmentation using geodesic active contours. Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tlandmarksFile\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\t[CannySigma]"
-              << "\n\t[CannyUpperThreshold]"
-              << "\n\t[CannyLowerThreshold]"
-              << "\n\t[RMSErrorForGeodesicActiveContour]"
-              << "\n\t[IterationsForGeodesicActiveContour]"
-              << "\n\t[CurvatureScalingForGeodesicActiveContour]"
-              << "\n\t[PropagationScalingForGeodesicActiveContour]"
-              << "\n\t[AdvectionScalingForGeodesicActiveContour]";
-    std::cerr << "\n\t[stopping time for fast marching]";
-    std::cerr << "\n\t[distance from seeds for fast marching]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile tinputImage toutputImage";
+    std::cerr << " [CannySigma]"
+              << " [CannyUpperThreshold]"
+              << " [CannyLowerThreshold]"
+              << " [RMSErrorForGeodesicActiveContour]"
+              << " [IterationsForGeodesicActiveContour]"
+              << " [CurvatureScalingForGeodesicActiveContour]"
+              << " [PropagationScalingForGeodesicActiveContour]"
+              << " [AdvectionScalingForGeodesicActiveContour]";
+    std::cerr << " [stoppingTime]";
+    std::cerr << " [distanceFromSeeds]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -61,15 +64,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
@@ -135,34 +130,110 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
                         inputImage->GetSpacing()[2] };
   double maxSpacing = (spacing[0] > spacing[1] ? spacing[0] : spacing[1]);
   maxSpacing = (maxSpacing > spacing[2] ? maxSpacing : spacing[2]);
-  
-  cannyEdgesGenerator->SetSigma( argc > 4 ? atof(argv[4]) : maxSpacing );
-  cannyEdgesGenerator->SetUpperThreshold( argc > 5 ? atof(argv[5]) : 150.0 );
-  cannyEdgesGenerator->SetLowerThreshold( argc > 6 ? atof(argv[6]) :  75.0 );
+  if( argc > 4 )
+    {
+    maxSpacing = std::stod( argv[4] );
+    }
+  cannyEdgesGenerator->SetSigma( maxSpacing );
+  TEST_SET_GET_VALUE( maxSpacing, cannyEdgesGenerator->GetSigma() );
+
+  double upperThreshold = 150.0;
+  if( argc > 5 )
+    {
+    upperThreshold = std::stod( argv[5] );
+    }
+  cannyEdgesGenerator->SetUpperThreshold( upperThreshold );
+  TEST_SET_GET_VALUE( upperThreshold, cannyEdgesGenerator->GetUpperThreshold() );
+
+  double lowerThreshold = 75.0;
+  if( argc > 6 )
+    {
+    lowerThreshold = std::stod( argv[6] );
+    }
+  cannyEdgesGenerator->SetLowerThreshold( lowerThreshold );
+  TEST_SET_GET_VALUE( lowerThreshold, cannyEdgesGenerator->GetLowerThreshold() );
+
 
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule< Dimension >;
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  segmentationModule->SetMaximumRMSError( argc > 7 ? atof(argv[7]) : 0.0002 );
-  segmentationModule->SetMaximumNumberOfIterations( argc > 8 ? atoi(argv[8]) : 300 );
-  segmentationModule->SetCurvatureScaling( argc > 9 ? atof(argv[9]) : 1.0 );
-  segmentationModule->SetPropagationScaling( argc > 10 ? atof(argv[10]) : 500.0 );
-  segmentationModule->SetAdvectionScaling( argc > 11 ? atof(argv[11]) : 0.0 );
-  segmentationModule->SetStoppingValue( argc > 12 ? atof(argv[12]) : 5.0 );
-  segmentationModule->SetDistanceFromSeeds( argc > 13 ? atof(argv[13]) : 0.5 );
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+  double maximumRMSError = 0.0002;
+  if( argc > 7 )
+    {
+    maximumRMSError = std::stod( argv[7] );
+    }
+  segmentationModule->SetMaximumRMSError( maximumRMSError );
+  TEST_SET_GET_VALUE( maximumRMSError, segmentationModule->GetMaximumRMSError() );
+
+  unsigned int maximumNumberOfIterations = 300;
+  if( argc > 8 )
+    {
+    maximumNumberOfIterations = std::stoi( argv[8] );
+    }
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
+
+  double curvatureScaling = 1.0;
+  if( argc > 9 )
+    {
+    curvatureScaling = std::stod( argv[9] );
+    }
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
+
+  double propagationScaling = 500.0;
+  if( argc > 10 )
+    {
+    propagationScaling = std::stod( argv[10] );
+    }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
+
+  double advectionScaling = 0.0;
+  if( argc > 11 )
+    {
+    advectionScaling = std::stod( argv[11] );
+    }
+  segmentationModule->SetAdvectionScaling( advectionScaling );
+  TEST_SET_GET_VALUE( advectionScaling, segmentationModule->GetAdvectionScaling() );
+
+  double stoppingValue = 5.0;
+  if( argc > 12 )
+    {
+    stoppingValue = std::stod( argv[12] );
+    }
+  segmentationModule->SetStoppingValue( stoppingValue );
+  TEST_SET_GET_VALUE( stoppingValue, segmentationModule->GetStoppingValue() );
+
+  double distanceFromSeeds = 0.5;
+  if( argc > 13 )
+    {
+    distanceFromSeeds = std::stod( argv[13] );
+    }
+  segmentationModule->SetDistanceFromSeeds( distanceFromSeeds );
+  TEST_SET_GET_VALUE( distanceFromSeeds, segmentationModule->GetDistanceFromSeeds() );
+
+
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
 
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
 
-  lesionSegmentationMethod->Update();
+  TRY_EXPECT_NO_EXCEPTION( lesionSegmentationMethod->Update() );
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -181,35 +252,17 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  // 
+  //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
-    {
-    lesionSegmentationMethod->Update();
-    std::cerr << "Failure to throw expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception " << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( lesionSegmentationMethod->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest8b.cxx
+++ b/test/itkLesionSegmentationMethodTest8b.cxx
@@ -22,15 +22,18 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkLandmarksReader.h"
+#include "itkTestingMacros.h"
 
+
+// Applies fast marhching followed by segmentation using geodesic active contours.
 int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Applies fast marhching followed by segmentation using geodesic active contours. Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tlandmarksFile\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\t[SigmoidBeta] [-ResampleThickSliceData] [-UseVesselEnhancingDiffusion]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage";
+    std::cerr << " [SigmoidBeta] [-ResampleThickSliceData] [-UseVesselEnhancingDiffusion]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -56,62 +59,51 @@ int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
+
 
   const InputImageType * inputImage = inputImageReader->GetOutput();
 
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
+
+
   const SeedSpatialObjectType * landmarks = landmarksReader->GetOutput();
 
   SegmentationMethodType::Pointer segmentationMethod = SegmentationMethodType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationMethod, LesionSegmentationImageFilter8,
+    ImageToImageFilter );
+
+
   segmentationMethod->SetInput( inputImage );
   segmentationMethod->SetSeeds( landmarks->GetPoints() );
   segmentationMethod->SetRegionOfInterest( inputImage->GetBufferedRegion() );
 
+  double sigmoidBeta = -500.0;
   if( argc > 4 )
     {
-    const double sigmoidBeta = atof( argv[4] );
-    std::cout << "Using SigmoidBeta = " << sigmoidBeta << std::endl;
-    segmentationMethod->SetSigmoidBeta( sigmoidBeta );
+    sigmoidBeta = std::stod( argv[4] );
     }
+  segmentationMethod->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, segmentationMethod->GetSigmoidBeta() );
 
   segmentationMethod->SetResampleThickSliceData( resampleThickSliceData );
   segmentationMethod->SetUseVesselEnhancingDiffusion( useVesselEnhancingDiffusion );
 
-  try 
-    {
-    segmentationMethod->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( segmentationMethod->Update() );
+
 
   OutputWriterType::Pointer writer = OutputWriterType::New();
   writer->SetFileName( argv[3] );
   writer->SetInput( segmentationMethod->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest9.cxx
+++ b/test/itkLesionSegmentationMethodTest9.cxx
@@ -29,21 +29,23 @@
 #include "itkSigmoidFeatureGenerator.h"
 #include "itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
 
+// Applies fast marhching followed by segmentation using geodesic active contours.
 int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Applies fast marhching followed by segmentation using geodesic active contours. Arguments" << std::endl;
-    std::cerr << argv[0] << "\n\tlandmarksFile\n\tinputImage\n\toutputImage ";
-    std::cerr << "\n\t[RMSErrorForGeodesicActiveContour]"
-              << "\n\t[IterationsForGeodesicActiveContour]"
-              << "\n\t[CurvatureScalingForGeodesicActiveContour]"
-              << "\n\t[PropagationScalingForGeodesicActiveContour]"
-              << "\n\t[AdvectionScalingForGeodesicActiveContour]";
-    std::cerr << "\n\t[stopping time for fast marching]";
-    std::cerr << "\n\t[distance from seeds for fast marching]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage";
+    std::cerr << " [RMSErrorForGeodesicActiveContour]"
+              << " [IterationsForGeodesicActiveContour]"
+              << " [CurvatureScalingForGeodesicActiveContour]"
+              << " [PropagationScalingForGeodesicActiveContour]"
+              << " [AdvectionScalingForGeodesicActiveContour]";
+    std::cerr << " [stoppingTime]";
+    std::cerr << " [distanceFromSeeds]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -58,15 +60,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
@@ -125,29 +119,87 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   gradientMagnitudeSigmoidGenerator->SetSigma( 1.0 );
   gradientMagnitudeSigmoidGenerator->SetAlpha( -100.0 );
   gradientMagnitudeSigmoidGenerator->SetBeta( 300 );
- 
+
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule< Dimension >;
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  segmentationModule->SetMaximumRMSError( argc > 4 ? atof(argv[4]) : 0.0002 );
-  segmentationModule->SetMaximumNumberOfIterations( argc > 5 ? atoi(argv[5]) : 300 );
-  segmentationModule->SetCurvatureScaling( argc > 6 ? atof(argv[6]) : 1.0 );
-  segmentationModule->SetPropagationScaling( argc > 7 ? atof(argv[7]) : 500.0 );
-  segmentationModule->SetAdvectionScaling( argc > 8 ? atof(argv[8]) : 0.0 );
-  segmentationModule->SetStoppingValue( argc > 9 ? atof(argv[9]) : 5.0 );
-  segmentationModule->SetDistanceFromSeeds( argc > 10 ? atof(argv[10]) : 2.0 );
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+
+  double maximumRMSError = 0.0002;
+  if( argc > 4 )
+    {
+    maximumRMSError = std::stod( argv[4] );
+    }
+  segmentationModule->SetMaximumRMSError( maximumRMSError );
+  TEST_SET_GET_VALUE( maximumRMSError, segmentationModule->GetMaximumRMSError() );
+
+  unsigned int maximumNumberOfIterations = 300;
+  if( argc > 5 )
+    {
+    maximumNumberOfIterations = std::stoi( argv[5] );
+    }
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
+
+  double curvatureScaling = 1.0;
+  if( argc > 6 )
+    {
+    curvatureScaling = std::stod( argv[6] );
+    }
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
+
+  double propagationScaling = 500.0;
+  if( argc > 7 )
+    {
+    propagationScaling = std::stod( argv[7] );
+    }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
+
+  double advectionScaling = 0.0;
+  if( argc > 8 )
+    {
+    advectionScaling = std::stod( argv[8] );
+    }
+  segmentationModule->SetAdvectionScaling( advectionScaling );
+  TEST_SET_GET_VALUE( advectionScaling, segmentationModule->GetAdvectionScaling() );
+
+  double stoppingValue = 5.0;
+  if( argc > 9 )
+    {
+    stoppingValue = std::stod( argv[9] );
+    }
+  segmentationModule->SetStoppingValue( stoppingValue );
+  TEST_SET_GET_VALUE( stoppingValue, segmentationModule->GetStoppingValue() );
+
+  double distanceFromSeeds = 2.5;
+  if( argc > 10 )
+    {
+    distanceFromSeeds = std::stod( argv[10] );
+    }
+  segmentationModule->SetDistanceFromSeeds( distanceFromSeeds );
+  TEST_SET_GET_VALUE( distanceFromSeeds, segmentationModule->GetDistanceFromSeeds() );
+
+
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
-  landmarksReader->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( landmarksReader->Update() );
 
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
-  lesionSegmentationMethod->Update();
 
-  
+  TRY_EXPECT_NO_EXCEPTION( lesionSegmentationMethod->Update() );
+
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -164,34 +216,16 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   // 
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
-    {
-    lesionSegmentationMethod->Update();
-    std::cerr << "Failure to throw expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception " << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( lesionSegmentationMethod->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLocalStructureImageFilterTest1.cxx
+++ b/test/itkLocalStructureImageFilterTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma alpha gamma]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma alpha gamma]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -60,25 +62,39 @@ int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
   using LocalStructureFilterType = itk::LocalStructureImageFilter< EigenValueImageType, OutputImageType >;
 
   LocalStructureFilterType::Pointer localStructure = LocalStructureFilterType::New();
-  
+
+  EXERCISE_BASIC_OBJECT_METHODS( localStructure,
+    LocalStructureImageFilter, UnaryFunctorImageFilter );
+
+
   hessian->SetInput( reader->GetOutput() );
   eigen->SetInput( hessian->GetOutput() );
   localStructure->SetInput( eigen->GetOutput() );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    hessian->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  hessian->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, hessian->GetSigma() );
 
+  double alpha = 0.25;
   if( argc > 4 )
     {
-    localStructure->SetAlpha( atof( argv[4] ) );
+    alpha = std::stod( argv[4] );
     }
+  localStructure->SetAlpha( alpha );
+  //TEST_SET_GET_VALUE( alpha, localStructure->GetAlpha() );
 
+  double gamma = 0.5;
   if( argc > 5 )
     {
-    localStructure->SetGamma( atof( argv[5] ) );
+    gamma = std::stod( argv[5] );
     }
+  localStructure->SetGamma( gamma );
+  //TEST_SET_GET_VALUE( gamma, localStructure->GetGamma() );
 
   eigen->SetDimension( Dimension );
 
@@ -87,19 +103,9 @@ int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( localStructure->GetOutput() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  std::cout << "Name Of Class = " << localStructure->GetNameOfClass() << std::endl;
 
-  localStructure->Print( std::cout );
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkLungWallFeatureGeneratorTest1.cxx
+++ b/test/itkLungWallFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [lungThreshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [lungThreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,21 +50,17 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using LungWallFeatureGeneratorType = itk::LungWallFeatureGenerator< Dimension >;
   using SpatialObjectType = LungWallFeatureGeneratorType::SpatialObjectType;
 
-  LungWallFeatureGeneratorType::Pointer  featureGenerator = LungWallFeatureGeneratorType::New();
-  
+  LungWallFeatureGeneratorType::Pointer featureGenerator = LungWallFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    LungWallFeatureGenerator, FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,21 +72,15 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+  LungWallFeatureGeneratorType::InputPixelType lungThreshold = 100;
   if( argc > 3 )
     {
-    featureGenerator->SetLungThreshold( atoi( argv[3] ) );
+    lungThreshold = std::stoi( argv[3] );
     }
+  featureGenerator->SetLungThreshold( lungThreshold );
+  TEST_SET_GET_VALUE( lungThreshold, featureGenerator->GetLungThreshold() );
 
-
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -104,36 +96,9 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
   writer->SetInput( outputImage );
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
-  featureGenerator->SetLungThreshold( 100 );
-  if( featureGenerator->GetLungThreshold() != 100 )
-    {
-    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetLungThreshold( 200 );
-  if( featureGenerator->GetLungThreshold() != 200 )
-    {
-    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkMaximumFeatureAggregatorTest1.cxx
+++ b/test/itkMaximumFeatureAggregatorTest1.cxx
@@ -20,6 +20,7 @@
 #include "itkLungWallFeatureGenerator.h"
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkSigmoidFeatureGenerator.h"
+#include "itkTestingMacros.h"
 
 
 int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
@@ -27,8 +28,9 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
 
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage ";
     std::cerr << " [lowerThreshold upperThreshold] " << std::endl;
     return EXIT_FAILURE;
     }
@@ -44,21 +46,17 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using AggregatorType = itk::MaximumFeatureAggregator< Dimension >;
 
-  AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+  AggregatorType::Pointer featureAggregator = AggregatorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregator,
+    FeatureAggregator);
+
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -67,7 +65,7 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -93,12 +91,13 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
 
-  featureAggregator->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
+
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -116,18 +115,9 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
-  featureAggregator->Print( std::cout );
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkMaximumFeatureAggregatorTest2.cxx
+++ b/test/itkMaximumFeatureAggregatorTest2.cxx
@@ -20,15 +20,17 @@
 #include "itkLungWallFeatureGenerator.h"
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkSigmoidFeatureGenerator.h"
+#include "itkTestingMacros.h"
+
 
 namespace itk
 {
 
-class MaximumFeatureAggregatorDerived : public MaximumFeatureAggregator<3>
+class MaximumFeatureAggregatorSurrogage : public MaximumFeatureAggregator<3>
 {
 public:
   /** Standard class type alias. */
-  using Self = MaximumFeatureAggregatorDerived;
+  using Self = MaximumFeatureAggregatorSurrogage;
   using Superclass = MaximumFeatureAggregator<3>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -37,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MaximumFeatureAggregatorDerived, MaximumFeatureAggregator);
+  itkTypeMacro(MaximumFeatureAggregatorSurrogage, MaximumFeatureAggregator);
 
   using InputFeatureType = Superclass::InputFeatureType;
 
@@ -54,11 +56,11 @@ public:
 
 int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage ";
     std::cerr << " [lowerThreshold upperThreshold] " << std::endl;
     return EXIT_FAILURE;
     }
@@ -74,21 +76,17 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
-  using AggregatorType = itk::MaximumFeatureAggregatorDerived;
+  using AggregatorType = itk::MaximumFeatureAggregatorSurrogage;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureAggregator,
+    MaximumFeatureAggregatorSurrogage,
+    MaximumFeatureAggregator );
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -97,7 +95,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -118,17 +116,35 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
   vesselnessGenerator->SetInput( inputObject );
   sigmoidGenerator->SetInput( inputObject );
 
-  lungWallGenerator->SetLungThreshold( -400 );
 
-  vesselnessGenerator->SetSigma( 1.0 );
-  vesselnessGenerator->SetAlpha1( 0.5 );
-  vesselnessGenerator->SetAlpha2( 2.0 );
- 
-  sigmoidGenerator->SetAlpha(  1.0  );
-  sigmoidGenerator->SetBeta( -200.0 );
- 
+  LungWallGeneratorType::InputPixelType lungThreshold = -400;
+  lungWallGenerator->SetLungThreshold( lungThreshold );
+  TEST_SET_GET_VALUE( lungThreshold, lungWallGenerator->GetLungThreshold() );
 
-  featureAggregator->Update();
+
+  double sigma = 1.0;
+  vesselnessGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, vesselnessGenerator->GetSigma() );
+
+  double alpha1 = 0.5;
+  vesselnessGenerator->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, vesselnessGenerator->GetAlpha1() );
+
+  double alpha2 = 2.0;
+  vesselnessGenerator->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, vesselnessGenerator->GetAlpha2() );
+
+
+  double alpha = 1.0;
+  sigmoidGenerator->SetAlpha( alpha );
+  TEST_SET_GET_VALUE( alpha, sigmoidGenerator->GetAlpha() );
+
+  double beta = -200.0;
+  sigmoidGenerator->SetBeta( beta );
+  TEST_SET_GET_VALUE( beta, sigmoidGenerator->GetBeta() );
+
+
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
 
    SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -146,51 +162,36 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureAggregator->Print( std::cout );
 
   //
   // Exercise GetInputFeature()
   //
   if( featureAggregator->GetInputFeature( 0 ) != lungWallGenerator->GetFeature() )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 0 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
   if( featureAggregator->GetInputFeature( 1 ) != vesselnessGenerator->GetFeature() )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 1 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
   if( featureAggregator->GetInputFeature( 2 ) != sigmoidGenerator->GetFeature() )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 2 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
-  try 
-    {
-    featureAggregator->GetInputFeature( 3 );
-    std::cerr << "Failure to catch an exception for GetInputFeature() with out of range argument" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( featureAggregator->GetInputFeature(3) );
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkMinimumFeatureAggregatorTest1.cxx
+++ b/test/itkMinimumFeatureAggregatorTest1.cxx
@@ -21,15 +21,16 @@
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkCannyEdgesFeatureGenerator.h"
 #include "itkSigmoidFeatureGenerator.h"
+#include "itkTestingMacros.h"
 
 
 int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage ";
     return EXIT_FAILURE;
     }
 
@@ -44,21 +45,17 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[1] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using AggregatorType = itk::MinimumFeatureAggregator< Dimension >;
 
-  AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+  AggregatorType::Pointer featureAggregator = AggregatorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureAggregator, MinimumFeatureAggregator,
+    FeatureAggregator );
+
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -67,10 +64,10 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
   CannyEdgesFeatureGeneratorType::Pointer  cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -108,7 +105,7 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
   cannyEdgesGenerator->SetUpperThreshold( 150.0 );
   cannyEdgesGenerator->SetLowerThreshold( 75.0 );
 
-  featureAggregator->Update();
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -126,17 +123,9 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  featureAggregator->Print( std::cout );
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkMinimumFeatureAggregatorTest2.cxx
+++ b/test/itkMinimumFeatureAggregatorTest2.cxx
@@ -20,15 +20,17 @@
 #include "itkLungWallFeatureGenerator.h"
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkSigmoidFeatureGenerator.h"
+#include "itkTestingMacros.h"
+
 
 namespace itk
 {
 
-class MinimumFeatureAggregatorDerived : public MinimumFeatureAggregator<3>
+class MinimumFeatureAggregatorSurrogate : public MinimumFeatureAggregator<3>
 {
 public:
   /** Standard class type alias. */
-  using Self = MinimumFeatureAggregatorDerived;
+  using Self = MinimumFeatureAggregatorSurrogate;
   using Superclass = MinimumFeatureAggregator<3>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -37,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MinimumFeatureAggregatorDerived, MinimumFeatureAggregator);
+  itkTypeMacro(MinimumFeatureAggregatorSurrogate, MinimumFeatureAggregator);
 
   using InputFeatureType = Superclass::InputFeatureType;
 
@@ -54,11 +56,11 @@ public:
 
 int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage ";
     return EXIT_FAILURE;
     }
 
@@ -73,21 +75,18 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[1] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
-  using AggregatorType = itk::MinimumFeatureAggregatorDerived;
+  using AggregatorType = itk::MinimumFeatureAggregatorSurrogate;
 
-  AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+  AggregatorType::Pointer featureAggregator = AggregatorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureAggregator,
+    MinimumFeatureAggregatorSurrogate,
+    MinimumFeatureAggregator );
+
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -96,7 +95,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -117,17 +116,35 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
   vesselnessGenerator->SetInput( inputObject );
   sigmoidGenerator->SetInput( inputObject );
 
-  lungWallGenerator->SetLungThreshold( -400 );
 
-  vesselnessGenerator->SetSigma( 1.0 );
-  vesselnessGenerator->SetAlpha1( 0.5 );
-  vesselnessGenerator->SetAlpha2( 2.0 );
- 
-  sigmoidGenerator->SetAlpha(  1.0  );
-  sigmoidGenerator->SetBeta( -200.0 );
- 
+  LungWallGeneratorType::InputPixelType lungThreshold = -400;
+  lungWallGenerator->SetLungThreshold( lungThreshold );
+  TEST_SET_GET_VALUE( lungThreshold, lungWallGenerator->GetLungThreshold() );
 
-  featureAggregator->Update();
+
+  double sigma = 1.0;
+  vesselnessGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, vesselnessGenerator->GetSigma() );
+
+  double alpha1 = 0.5;
+  vesselnessGenerator->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, vesselnessGenerator->GetAlpha1() );
+
+  double alpha2 = 2.0;
+  vesselnessGenerator->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, vesselnessGenerator->GetAlpha2() );
+
+
+  double alpha = 1.0;
+  sigmoidGenerator->SetAlpha( alpha );
+  TEST_SET_GET_VALUE( alpha, sigmoidGenerator->GetAlpha() );
+
+  double beta = -200.0;
+  sigmoidGenerator->SetBeta( beta );
+  TEST_SET_GET_VALUE( beta, sigmoidGenerator->GetBeta() );
+
+
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -145,51 +162,35 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureAggregator->Print( std::cout );
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   //
   // Exercise GetInputFeature()
   //
   if( featureAggregator->GetInputFeature( 0 ) != lungWallGenerator->GetFeature() )
     {
+     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 0 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
   if( featureAggregator->GetInputFeature( 1 ) != vesselnessGenerator->GetFeature() )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 1 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
   if( featureAggregator->GetInputFeature( 2 ) != sigmoidGenerator->GetFeature() )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Failure to recover feature 2 with GetInputFeature()" << std::endl;
     return EXIT_FAILURE;
     }
 
-  try 
-    {
-    featureAggregator->GetInputFeature( 3 );
-    std::cerr << "Failure to catch an exception for GetInputFeature() with out of range argument" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception" << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( featureAggregator->GetInputFeature( 3 ) );
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
@@ -19,14 +19,17 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 {
 
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [lungThreshold]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [lungThreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,21 +51,17 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using FeatureGeneratorType = itk::MorphologicalOpeningFeatureGenerator< Dimension >;
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
-  FeatureGeneratorType::Pointer  featureGenerator = FeatureGeneratorType::New();
-  
+  FeatureGeneratorType::Pointer featureGenerator = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    MorphologicalOpenningFeatureGenerator, FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,22 +73,16 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+  FeatureGeneratorType::InputPixelType  lungThreshold = -400;
   if( argc > 3 )
     {
-    featureGenerator->SetLungThreshold( atoi( argv[3] ) );
+    lungThreshold = std::stoi( argv[3] );
     }
+  featureGenerator->SetLungThreshold( lungThreshold );
+  TEST_SET_GET_VALUE( lungThreshold, featureGenerator->GetLungThreshold() );
 
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
@@ -104,36 +97,9 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
   writer->SetInput( outputImage );
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
-  featureGenerator->SetLungThreshold( 100 );
-  if( featureGenerator->GetLungThreshold() != 100 )
-    {
-    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  featureGenerator->SetLungThreshold( 200 );
-  if( featureGenerator->GetLungThreshold() != 200 )
-    {
-    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkRegionCompetitionImageFilterTest1.cxx
+++ b/test/itkRegionCompetitionImageFilterTest1.cxx
@@ -19,6 +19,7 @@ const
 #include "itkRegionCompetitionImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkImage.h"
+#include "itkTestingMacros.h"
 
 
 int itkRegionCompetitionImageFilterTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
@@ -149,13 +150,16 @@ int itkRegionCompetitionImageFilterTest1( int itkNotUsed(argc), char * itkNotUse
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput( inputImage );
   writer->SetFileName("inputCompetitionImage.mha");
-  writer->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
   thresholderFilter->SetInput( inputImage );
   thresholderFilter->SetUpperThreshold( 2000 );
   thresholderFilter->SetLowerThreshold(  400 );
-  thresholderFilter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( thresholderFilter->Update() );
+
   componentsFilter->SetInput( thresholderFilter->GetOutput() );
   relabelerFilter->SetInput( componentsFilter->GetOutput() );
 
@@ -166,17 +170,23 @@ int itkRegionCompetitionImageFilterTest1( int itkNotUsed(argc), char * itkNotUse
   LabelWriterType::Pointer labelWriter = LabelWriterType::New();
   labelWriter->SetInput( relabelerFilter->GetOutput() );
   labelWriter->SetFileName("labeledImage.mha");
-  labelWriter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( labelWriter->Update() );
+
 
   competitionFilter->SetInput( inputImage );
   competitionFilter->SetInputLabels( labelImagePt);
-  competitionFilter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( competitionFilter->Update() );
+
 
   // Write the output image
   labelWriter->SetInput( competitionFilter->GetOutput() );
   labelWriter->SetFileName("labeledSegmentedImage.mha");
-  labelWriter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( labelWriter->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSatoLocalStructureFeatureGeneratorTest1.cxx
+++ b/test/itkSatoLocalStructureFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkSatoLocalStructureFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma alpha gamma]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma alpha gamma]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,20 +50,16 @@ int itkSatoLocalStructureFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using SatoLocalStructureFeatureGeneratorType = itk::SatoLocalStructureFeatureGenerator< Dimension >;
   using SpatialObjectType = SatoLocalStructureFeatureGeneratorType::SpatialObjectType;
 
-  SatoLocalStructureFeatureGeneratorType::Pointer  featureGenerator = SatoLocalStructureFeatureGeneratorType::New();
+  SatoLocalStructureFeatureGeneratorType::Pointer featureGenerator = SatoLocalStructureFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    SatoLocalStructureFeatureGenerator, FeatureGenerator );
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -74,31 +72,33 @@ int itkSatoLocalStructureFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double alpha = 0.5;
   if( argc > 4 )
     {
-    featureGenerator->SetAlpha( atof( argv[4] ) );
+    alpha = std::stod( argv[4] );
     }
+  featureGenerator->SetAlpha( alpha );
+  TEST_SET_GET_VALUE( alpha, featureGenerator->GetAlpha() );
 
+  double gamma = 2.0;
   if( argc > 5 )
     {
-    featureGenerator->SetGamma( atof( argv[5] ) );
+    gamma = std::stod( argv[5] );
     }
+  featureGenerator->SetGamma( gamma );
+  TEST_SET_GET_VALUE( gamma, featureGenerator->GetGamma() );
 
 
-  try
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -113,22 +113,9 @@ int itkSatoLocalStructureFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( outputImage );
 
-
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSatoVesselnessFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkSatoVesselnessFeatureGeneratorMultiScaleTest1.cxx
@@ -18,15 +18,16 @@
 #include "itkImageFileWriter.h"
 #include "itkSatoVesselnessFeatureGenerator.h"
 #include "itkMaximumFeatureAggregator.h"
+#include "itkTestingMacros.h"
 
 
 int itkSatoVesselnessFeatureGeneratorMultiScaleTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage ";
     std::cerr << " [sigma alpha1 alpha2]" << std::endl;
     return EXIT_FAILURE;
     }
@@ -42,53 +43,81 @@ int itkSatoVesselnessFeatureGeneratorMultiScaleTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[1] );
 
-  try
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using AggregatorType = itk::MaximumFeatureAggregator< Dimension >;
 
-  AggregatorType::Pointer  featureAggregator = AggregatorType::New();
+  AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
   using FeatureGeneratorType = itk::SatoVesselnessFeatureGenerator< Dimension >;
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
   FeatureGeneratorType::Pointer  featureGenerator1 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator2 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator3 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator4 = FeatureGeneratorType::New();
 
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator1,
+    SatoVesselnessFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer  featureGenerator2 = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator2,
+    SatoVesselnessFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer featureGenerator3 = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator3,
+    SatoVesselnessFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer featureGenerator4 = FeatureGeneratorType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator4,
+    SatoVesselnessFeatureGenerator, FeatureGenerator );
+
+
+  double smallestSigma = 1.0;
   if( argc > 3 )
     {
-    double smallestSigma = atof( argv[3] );
-    featureGenerator1->SetSigma( smallestSigma );
-    featureGenerator2->SetSigma( smallestSigma * 2.0 );
-    featureGenerator3->SetSigma( smallestSigma * 4.0 );
-    featureGenerator4->SetSigma( smallestSigma * 8.0 );
+    smallestSigma = std::stod( argv[3] );
     }
+  featureGenerator1->SetSigma( smallestSigma );
+  TEST_SET_GET_VALUE( smallestSigma, featureGenerator1->GetSigma() );
+  double smallestSigma2 = smallestSigma * 2.0;
+  featureGenerator2->SetSigma( smallestSigma2 );
+  TEST_SET_GET_VALUE( smallestSigma2, featureGenerator2->GetSigma() );
+  double smallestSigma3 = smallestSigma * 4.0;
+  featureGenerator3->SetSigma( smallestSigma3 );
+  TEST_SET_GET_VALUE( smallestSigma3, featureGenerator3->GetSigma() );
+  double smallestSigma4 = smallestSigma * 8.0;
+  featureGenerator4->SetSigma( smallestSigma4 );
+  TEST_SET_GET_VALUE( smallestSigma4, featureGenerator4->GetSigma() );
 
+  double alpha1 = 0.5;
   if( argc > 4 )
     {
-    featureGenerator1->SetAlpha1( atof( argv[4] ) );
-    featureGenerator2->SetAlpha1( atof( argv[4] ) );
-    featureGenerator3->SetAlpha1( atof( argv[4] ) );
-    featureGenerator4->SetAlpha1( atof( argv[4] ) );
+    alpha1 = std::stod( argv[4] );
     }
+  featureGenerator1->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator1->GetAlpha1() );
+  featureGenerator2->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator2->GetAlpha1() );
+  featureGenerator3->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator3->GetAlpha1() );
+  featureGenerator4->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator4->GetAlpha1() );
 
+  double alpha2 = 2.0;
   if( argc > 5 )
     {
-    featureGenerator1->SetAlpha2( atof( argv[5] ) );
-    featureGenerator2->SetAlpha2( atof( argv[5] ) );
-    featureGenerator3->SetAlpha2( atof( argv[5] ) );
-    featureGenerator4->SetAlpha2( atof( argv[5] ) );
+    alpha2 = std::stod( argv[5] );
     }
+  featureGenerator1->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator1->GetAlpha2() );
+  featureGenerator2->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator2->GetAlpha2() );
+  featureGenerator3->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator3->GetAlpha2() );
+  featureGenerator4->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator4->GetAlpha2() );
+
 
   using SpatialObjectType = AggregatorType::SpatialObjectType;
 
@@ -111,15 +140,8 @@ int itkSatoVesselnessFeatureGeneratorMultiScaleTest1( int argc, char * argv [] )
   featureAggregator->AddFeatureGenerator( featureGenerator3 );
   featureAggregator->AddFeatureGenerator( featureGenerator4 );
 
-  try
-    {
-    featureAggregator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
+
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -138,17 +160,12 @@ int itkSatoVesselnessFeatureGeneratorMultiScaleTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
   featureAggregator->Print( std::cout );
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSatoVesselnessFeatureGeneratorTest1.cxx
+++ b/test/itkSatoVesselnessFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkSatoVesselnessFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma alpha1 alpha2]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma alpha1 alpha2]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,20 +50,16 @@ int itkSatoVesselnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using SatoVesselnessFeatureGeneratorType = itk::SatoVesselnessFeatureGenerator< Dimension >;
   using SpatialObjectType = SatoVesselnessFeatureGeneratorType::SpatialObjectType;
 
-  SatoVesselnessFeatureGeneratorType::Pointer  featureGenerator = SatoVesselnessFeatureGeneratorType::New();
+  SatoVesselnessFeatureGeneratorType::Pointer featureGenerator = SatoVesselnessFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    SatoVesselnessFeatureGenerator, FeatureGenerator );
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -74,31 +72,33 @@ int itkSatoVesselnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double alpha1 = 0.5;
   if( argc > 4 )
     {
-    featureGenerator->SetAlpha1( atof( argv[4] ) );
+    alpha1 = std::stod( argv[4] );
     }
+  featureGenerator->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator->GetAlpha1() );
 
+  double alpha2 = 2.0;
   if( argc > 5 )
     {
-    featureGenerator->SetAlpha2( atof( argv[5] ) );
+    alpha2 = std::stod( argv[5] );
     }
+  featureGenerator->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator->GetAlpha2() );
 
 
-  try
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -113,21 +113,9 @@ int itkSatoVesselnessFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( outputImage );
 
-
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
@@ -18,15 +18,16 @@
 #include "itkImageFileWriter.h"
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkMinimumFeatureAggregator.h"
+#include "itkTestingMacros.h"
 
 
 int itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage ";
     std::cerr << " [sigma alpha1 alpha2 " << std::endl;
     std::cerr << " sigmoidAlpha sigmoidBeta]" << std::endl;
     return EXIT_FAILURE;
@@ -43,15 +44,7 @@ int itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1( int argc, char * ar
 
   inputImageReader->SetFileName( argv[1] );
 
-  try
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using AggregatorType = itk::MinimumFeatureAggregator< Dimension >;
@@ -61,51 +54,99 @@ int itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1( int argc, char * ar
   using FeatureGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
-  FeatureGeneratorType::Pointer  featureGenerator1 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator2 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator3 = FeatureGeneratorType::New();
-  FeatureGeneratorType::Pointer  featureGenerator4 = FeatureGeneratorType::New();
+  FeatureGeneratorType::Pointer featureGenerator1 = FeatureGeneratorType::New();
 
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator1,
+    SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer featureGenerator2 = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator2,
+    SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer featureGenerator3 = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator3,
+    SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator );
+
+  FeatureGeneratorType::Pointer featureGenerator4 = FeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator4,
+    SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator );
+
+
+  double smallestSigma = 1.0;
   if( argc > 3 )
     {
-    double smallestSigma = atof( argv[3] );
-    featureGenerator1->SetSigma( smallestSigma );
-    featureGenerator2->SetSigma( smallestSigma * 2.0 );
-    featureGenerator3->SetSigma( smallestSigma * 4.0 );
-    featureGenerator4->SetSigma( smallestSigma * 8.0 );
+    smallestSigma = std::stod( argv[3] );
     }
+  featureGenerator1->SetSigma( smallestSigma );
+  TEST_SET_GET_VALUE( smallestSigma, featureGenerator1->GetSigma() );
+  double smallestSigma2 = smallestSigma * 2.0;
+  featureGenerator2->SetSigma( smallestSigma2 );
+  TEST_SET_GET_VALUE( smallestSigma2, featureGenerator2->GetSigma() );
+  double smallestSigma3 = smallestSigma * 4.0;
+  featureGenerator3->SetSigma( smallestSigma3 );
+  TEST_SET_GET_VALUE( smallestSigma3, featureGenerator3->GetSigma() );
+  double smallestSigma4 = smallestSigma * 8.0;
+  featureGenerator4->SetSigma( smallestSigma4 );
+  TEST_SET_GET_VALUE( smallestSigma4, featureGenerator4->GetSigma() );
 
+  double alpha1 = 0.5;
   if( argc > 4 )
     {
-    featureGenerator1->SetAlpha1( atof( argv[4] ) );
-    featureGenerator2->SetAlpha1( atof( argv[4] ) );
-    featureGenerator3->SetAlpha1( atof( argv[4] ) );
-    featureGenerator4->SetAlpha1( atof( argv[4] ) );
+    alpha1 = std::stod( argv[4] );
     }
+  featureGenerator1->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator1->GetAlpha1() );
+  featureGenerator2->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator2->GetAlpha1() );
+  featureGenerator3->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator3->GetAlpha1() );
+  featureGenerator4->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator4->GetAlpha1() );
 
+  double alpha2 = 2.0;
   if( argc > 5 )
     {
-    featureGenerator1->SetAlpha2( atof( argv[5] ) );
-    featureGenerator2->SetAlpha2( atof( argv[5] ) );
-    featureGenerator3->SetAlpha2( atof( argv[5] ) );
-    featureGenerator4->SetAlpha2( atof( argv[5] ) );
+    alpha2 = std::stod( argv[5] );
     }
+  featureGenerator1->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator1->GetAlpha2() );
+  featureGenerator2->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator2->GetAlpha2() );
+  featureGenerator3->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator3->GetAlpha2() );
+  featureGenerator4->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator4->GetAlpha2() );
 
+  double sigmoidAlpha = -1.0;
   if( argc > 6 )
     {
-    featureGenerator1->SetSigmoidAlpha( atof( argv[6] ) );
-    featureGenerator2->SetSigmoidAlpha( atof( argv[6] ) );
-    featureGenerator3->SetSigmoidAlpha( atof( argv[6] ) );
-    featureGenerator4->SetSigmoidAlpha( atof( argv[6] ) );
+    sigmoidAlpha = std::stod( argv[6] );
     }
+  featureGenerator1->SetSigmoidAlpha( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator1->GetSigmoidAlpha() );
+  featureGenerator2->SetSigmoidAlpha( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator2->GetSigmoidAlpha() );
+  featureGenerator3->SetSigmoidAlpha( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator3->GetSigmoidAlpha() );
+  featureGenerator4->SetSigmoidAlpha( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator4->GetSigmoidAlpha() );
 
+  double sigmoidBeta = 90.0;
   if( argc > 7 )
     {
-    featureGenerator1->SetSigmoidBeta( atof( argv[7] ) );
-    featureGenerator2->SetSigmoidBeta( atof( argv[7] ) );
-    featureGenerator3->SetSigmoidBeta( atof( argv[7] ) );
-    featureGenerator4->SetSigmoidBeta( atof( argv[7] ) );
+    sigmoidBeta = std::stod( argv[7] );
     }
+  featureGenerator1->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, featureGenerator1->GetSigmoidBeta() );
+  featureGenerator2->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, featureGenerator2->GetSigmoidBeta() );
+  featureGenerator3->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, featureGenerator3->GetSigmoidBeta() );
+  featureGenerator4->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, featureGenerator4->GetSigmoidBeta() );
 
 
   using SpatialObjectType = AggregatorType::SpatialObjectType;
@@ -129,15 +170,8 @@ int itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1( int argc, char * ar
   featureAggregator->AddFeatureGenerator( featureGenerator3 );
   featureAggregator->AddFeatureGenerator( featureGenerator4 );
 
-  try
-    {
-    featureAggregator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureAggregator->Update() );
+
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -156,17 +190,11 @@ int itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1( int argc, char * ar
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   featureAggregator->Print( std::cout );
 
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSatoVesselnessSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkSatoVesselnessSigmoidFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkSatoVesselnessSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [sigma alpha1 alpha2 ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [sigma alpha1 alpha2 ";
     std::cerr << " sigmoidAlpha sigmoidBeta]" << std::endl;
     return EXIT_FAILURE;
     }
@@ -49,20 +51,16 @@ int itkSatoVesselnessSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using SatoVesselnessSigmoidFeatureGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   using SpatialObjectType = SatoVesselnessSigmoidFeatureGeneratorType::SpatialObjectType;
 
-  SatoVesselnessSigmoidFeatureGeneratorType::Pointer  featureGenerator = SatoVesselnessSigmoidFeatureGeneratorType::New();
+  SatoVesselnessSigmoidFeatureGeneratorType::Pointer featureGenerator = SatoVesselnessSigmoidFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    SatoVesselnessSigmoidFeatureGenerator, SatoVesselnessFeatureGenerator );
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -75,41 +73,49 @@ int itkSatoVesselnessSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
+
+  double sigma = 1.0;
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    sigma = std::stod( argv[3] );
     }
+  featureGenerator->SetSigma( sigma );
+  TEST_SET_GET_VALUE( sigma, featureGenerator->GetSigma() );
 
+  double alpha1 = 0.5;
   if( argc > 4 )
     {
-    featureGenerator->SetAlpha1( atof( argv[4] ) );
+    alpha1 = std::stod( argv[4] );
     }
+  featureGenerator->SetAlpha1( alpha1 );
+  TEST_SET_GET_VALUE( alpha1, featureGenerator->GetAlpha1() );
 
+  double alpha2 = 2.0;
   if( argc > 5 )
     {
-    featureGenerator->SetAlpha2( atof( argv[5] ) );
+    alpha2 = std::stod( argv[5] );
     }
+  featureGenerator->SetAlpha2( alpha2 );
+  TEST_SET_GET_VALUE( alpha2, featureGenerator->GetAlpha2() );
 
+  double sigmoidAlpha = 1.0;
   if( argc > 6 )
     {
-    featureGenerator->SetSigmoidAlpha( atof( argv[6] ) );
+    sigmoidAlpha = std::stod( argv[6] );
     }
+  featureGenerator->SetSigmoidAlpha( sigmoidAlpha );
+  TEST_SET_GET_VALUE( sigmoidAlpha, featureGenerator->GetSigmoidAlpha() );
 
+  double sigmoidBeta = -200.0;
   if( argc > 7 )
     {
-    featureGenerator->SetSigmoidBeta( atof( argv[7] ) );
+    sigmoidBeta = std::stod( argv[7] );
     }
+  featureGenerator->SetSigmoidBeta( sigmoidBeta );
+  TEST_SET_GET_VALUE( sigmoidBeta, featureGenerator->GetSigmoidBeta() );
 
 
-  try
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -125,21 +131,9 @@ int itkSatoVesselnessSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSegmentationModuleTest1.cxx
+++ b/test/itkSegmentationModuleTest1.cxx
@@ -18,6 +18,8 @@
 #include "itkSpatialObject.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
+
 
 int itkSegmentationModuleTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
 {
@@ -26,7 +28,11 @@ int itkSegmentationModuleTest1( int itkNotUsed(argc), char * itkNotUsed(argv) []
   using SegmentationModuleType = itk::SegmentationModule< Dimension >;
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule, SegmentationModule,
+    ProcessObject );
+
 
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
@@ -38,14 +44,9 @@ int itkSegmentationModuleTest1( int itkNotUsed(argc), char * itkNotUsed(argv) []
 
   segmentationModule->SetFeature( featureObject );
 
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
-  segmentationModule->Update();
 
-  SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
-
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkSegmentationVolumeEstimatorTest1.cxx
@@ -18,6 +18,8 @@
 #include "itkSpatialObject.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
+
 
 namespace itk
 {
@@ -27,12 +29,13 @@ class VolumeEstimatorSurrogate : public SegmentationVolumeEstimator<3>
 public:
   /** Standard class type alias. */
   using Self = VolumeEstimatorSurrogate;
-  using Superclass = ProcessObject;
+  using Superclass = SegmentationVolumeEstimator;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
 
   itkNewMacro( Self );
 
+  itkTypeMacro( VolumeEstimatorSurrogate, SegmentationVolumeEstimator );
 };
 
 }
@@ -44,7 +47,10 @@ int itkSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), char * itkNotUsed
 
   using VolumeEstimatorType = itk::VolumeEstimatorSurrogate;
 
-  VolumeEstimatorType::Pointer  volumeEstimator = VolumeEstimatorType::New();
+  VolumeEstimatorType::Pointer volumeEstimator = VolumeEstimatorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( volumeEstimator, VolumeEstimatorSurrogate,
+    SegmentationVolumeEstimator );
 
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
@@ -52,7 +58,8 @@ int itkSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), char * itkNotUsed
 
   volumeEstimator->SetInput( inputObject );
 
-  volumeEstimator->Update();
+  TRY_EXPECT_NO_EXCEPTION( volumeEstimator->Update() );
+
 
   VolumeEstimatorType::RealType volume1 = volumeEstimator->GetVolume();
 
@@ -60,13 +67,12 @@ int itkSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), char * itkNotUsed
 
   if( volumeObject->Get() != volume1 )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in GetVolumeOutput() and/or GetVolume() " << std::endl;
     return EXIT_FAILURE;
     }
 
-  volumeEstimator->Print( std::cout );
 
-  std::cout << "Class name = " << volumeEstimator->GetNameOfClass() << std::endl;
-
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
@@ -20,14 +20,16 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
+#include "itkTestingMacros.h"
+
 
 int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 {
-
   if( argc < 4 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage featureImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage featureImage outputImage ";
     std::cerr << " [propagationScaling curvatureScaling maximumNumberOfIterations]" << std::endl;
     return EXIT_FAILURE;
     }
@@ -37,8 +39,13 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 
   using SegmentationModuleType = itk::ShapeDetectionLevelSetSegmentationModule< Dimension >;
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    ShapeDetectionLevelSetSegmentationModule,
+    SinglePhaseLevelSetSegmentationModule );
+
+
   using InputImageType = SegmentationModuleType::InputImageType;
   using FeatureImageType = SegmentationModuleType::FeatureImageType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -56,6 +63,8 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 
   inputReader->SetFileName( argv[1] );
 
+  TRY_EXPECT_NO_EXCEPTION( inputReader->Update() );
+
 
   RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
   rescaler->SetInput( inputReader->GetOutput() );
@@ -63,23 +72,12 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   rescaler->SetOutputMinimum( -4.0 );
   rescaler->SetOutputMaximum(  4.0 );
 
-  inputWriter->SetFileName( "inputSegmentation.mha" );
+  TRY_EXPECT_NO_EXCEPTION( rescaler->Update() );
 
-  inputWriter->SetInput( rescaler->GetOutput() );
-  inputWriter->Update();
 
   featureReader->SetFileName( argv[2] );
 
-  try 
-    {
-    rescaler->Update();
-    featureReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( featureReader->Update() );
 
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -95,36 +93,38 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   segmentationModule->SetInput( inputObject );
   segmentationModule->SetFeature( featureObject );
 
-  double propagationScaling = 1.0;
-  double curvatureScaling = 1.0;
-  unsigned int maximumNumberOfIterations = 50;
 
+  double propagationScaling = 1.0;
   if( argc > 4 )
     {
-    propagationScaling = atof( argv[4] ); 
+    propagationScaling = std::stod( argv[4] );
     }
+  segmentationModule->SetPropagationScaling( propagationScaling );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
 
+  double curvatureScaling = 1.0;
   if( argc > 5 )
     {
-    curvatureScaling = atof( argv[5] ); 
+    curvatureScaling = std::stod( argv[5] );
     }
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
 
+  unsigned int maximumNumberOfIterations = 50;
   if( argc > 6 )
     {
-    maximumNumberOfIterations = atoi( argv[6] ); 
+    maximumNumberOfIterations = std::stoi( argv[6] );
     }
-
-
-  segmentationModule->SetPropagationScaling( propagationScaling );
-  segmentationModule->SetCurvatureScaling( curvatureScaling );
   segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
 
-  segmentationModule->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -134,20 +134,9 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkSigmoidFeatureGeneratorTest1.cxx
@@ -19,14 +19,16 @@
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkTestingMacros.h"
+
 
 int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [alpha beta]" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage outputImage [alpha beta]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -48,21 +50,18 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
-    {
-    reader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( reader->Update() );
+
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   using SpatialObjectType = SigmoidFeatureGeneratorType::SpatialObjectType;
 
-  SigmoidFeatureGeneratorType::Pointer  featureGenerator = SigmoidFeatureGeneratorType::New();
-  
+  SigmoidFeatureGeneratorType::Pointer featureGenerator = SigmoidFeatureGeneratorType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( featureGenerator,
+    SigmoidFeatureGenerator,
+    FeatureGenerator );
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -74,45 +73,24 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->SetInput( inputObject );
 
-  double alpha =   1.0;
-  double beta  = 100.0;
-
+  double alpha = 1.0;
   if( argc > 3 )
     {
-    alpha = atof( argv[3] );
+    alpha = std::stod( argv[3] );
     }
+  featureGenerator->SetAlpha( alpha );
+  TEST_SET_GET_VALUE( alpha, featureGenerator->GetAlpha() );
 
+  double beta  = 100.0;
   if( argc > 4 )
     {
-    beta = atof( argv[4] );
+    beta = std::stod( argv[4] );
     }
-
-  featureGenerator->SetAlpha( 0.0 );
-  featureGenerator->SetBeta( 0.0 );
-
-  featureGenerator->SetAlpha( alpha );
-  if( featureGenerator->GetAlpha() != alpha )
-    {
-    std::cerr << "Error in Set/GetAlpha()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
   featureGenerator->SetBeta( beta );
-  if( featureGenerator->GetBeta() != beta )
-    {
-    std::cerr << "Error in Set/GetBeta()" << std::endl;
-    return EXIT_FAILURE;
-    }
+  TEST_SET_GET_VALUE( beta, featureGenerator->GetBeta() );
 
-  try 
-    {
-    featureGenerator->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( featureGenerator->Update() );
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -128,22 +106,9 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
 
-  std::cout << "Name Of Class = " << featureGenerator->GetNameOfClass() << std::endl;
-
-  featureGenerator->Print( std::cout );
-
- 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
@@ -18,6 +18,8 @@
 #include "itkSpatialObject.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageMaskSpatialObject.h"
+#include "itkTestingMacros.h"
+
 
 int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
 {
@@ -26,8 +28,13 @@ int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * 
   using SegmentationModuleType = itk::SinglePhaseLevelSetSegmentationModule< Dimension >;
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
-  SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+  SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( segmentationModule,
+    SinglePhaseLevelSetSegmentationModule,
+    SegmentationModule );
+
+
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
   ImageSpatialObjectType::Pointer inputObject = ImageSpatialObjectType::New();
@@ -38,63 +45,30 @@ int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * 
 
   segmentationModule->SetFeature( featureObject );
 
-  // Initialize values to a base level
-  segmentationModule->SetPropagationScaling ( 1.0 );
-  segmentationModule->SetCurvatureScaling ( 1.0 );
-  segmentationModule->SetAdvectionScaling ( 1.0 );
-  segmentationModule->SetMaximumRMSError ( 1.0 );
-  segmentationModule->SetMaximumNumberOfIterations ( 1 );
-
   constexpr double propagationScaling = 1.3;
+  segmentationModule->SetPropagationScaling( propagationScaling  );
+  TEST_SET_GET_VALUE( propagationScaling, segmentationModule->GetPropagationScaling() );
+
   constexpr double curvatureScaling = 1.7;
+  segmentationModule->SetCurvatureScaling( curvatureScaling );
+  TEST_SET_GET_VALUE( curvatureScaling, segmentationModule->GetCurvatureScaling() );
+
   constexpr double advectionScaling = 1.9;
+  segmentationModule->SetAdvectionScaling( advectionScaling );
+  TEST_SET_GET_VALUE( advectionScaling, segmentationModule->GetAdvectionScaling() );
+
   constexpr double maximumRMSError = 0.01;
+  segmentationModule->SetMaximumRMSError( maximumRMSError );
+  TEST_SET_GET_VALUE( maximumRMSError, segmentationModule->GetMaximumRMSError() );
+
   constexpr unsigned int maximumNumberOfIterations = 179;
-
-  // Set specific values and check them back
-  segmentationModule->SetPropagationScaling ( propagationScaling );
-  if( segmentationModule->GetPropagationScaling() != propagationScaling )
-    {
-    std::cerr << "Error in Set/GetPropagationScaling()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  segmentationModule->SetCurvatureScaling ( curvatureScaling );
-  if( segmentationModule->GetCurvatureScaling() != curvatureScaling )
-    {
-    std::cerr << "Error in Set/GetCurvatureScaling()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  segmentationModule->SetAdvectionScaling ( advectionScaling );
-  if( segmentationModule->GetAdvectionScaling() != advectionScaling )
-    {
-    std::cerr << "Error in Set/GetAdvectionScaling()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  segmentationModule->SetMaximumRMSError ( maximumRMSError );
-  if( segmentationModule->GetMaximumRMSError() != maximumRMSError )
-    {
-    std::cerr << "Error in Set/GetMaximumRMSError()" << std::endl;
-    return EXIT_FAILURE;
-    }
-
-  segmentationModule->SetMaximumNumberOfIterations ( maximumNumberOfIterations );
-  if( segmentationModule->GetMaximumNumberOfIterations() != maximumNumberOfIterations )
-    {
-    std::cerr << "Error in Set/GetMaximumNumberOfIterations()" << std::endl;
-    return EXIT_FAILURE;
-    }
+  segmentationModule->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations() );
 
 
-  segmentationModule->Update();
+  TRY_EXPECT_NO_EXCEPTION( segmentationModule->Update() );
 
-  SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  segmentationModule->Print( std::cout );
-
-  std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
+++ b/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
@@ -24,13 +24,16 @@
 #include "itkImageFileWriter.h"
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkVotingBinaryHoleFillFloodingImageFilter.h"
+#include "itkTestingMacros.h"
+
 
 int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
 {
   if( argc < 7 )
     {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile outputImageFile inputThreshold radius majority maxNumberOfIterations" << std::endl;
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImageFile outputImageFile inputThreshold radius majority maxNumberOfIterations" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -57,7 +60,7 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
 
   ThresholderType::Pointer thresholder = ThresholderType::New();
 
-  thresholder->SetLowerThreshold( atoi( argv[3] ) );
+  thresholder->SetLowerThreshold( std::stoi( argv[3] ) );
   thresholder->SetUpperThreshold( itk::NumericTraits< InputPixelType >::max() );
 
   thresholder->SetOutsideValue(  0 );
@@ -68,10 +71,15 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
 
   FilterType::Pointer filter = FilterType::New();
 
-  const unsigned int radius = atoi( argv[4] );
+  EXERCISE_BASIC_OBJECT_METHODS( filter,
+    VotingBinaryHoleFillFloodingImageFilter,
+    VotingBinaryImageFilter );
+
+
+  const unsigned int radius = std::stoi( argv[4] );
 
   OutputImageType::SizeType indexRadius;
-  
+
   indexRadius[0] = radius; // radius along x
   indexRadius[1] = radius; // radius along y
   indexRadius[2] = radius; // radius along z
@@ -81,31 +89,27 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
   filter->SetBackgroundValue(   0 );
   filter->SetForegroundValue( 255 );
 
-  const unsigned int majorityThreshold = atoi( argv[5] );
+  const unsigned int majorityThreshold = std::stoi( argv[5] );
 
   filter->SetMajorityThreshold( majorityThreshold  );
 
-  const unsigned int maximumNumberOfIterations = atoi( argv[6] );
-
-  filter->SetMaximumNumberOfIterations( maximumNumberOfIterations  );
-
-  if( filter->GetMaximumNumberOfIterations() != maximumNumberOfIterations )
-    {
-    std::cerr << "Error in Set/GetMaximumNumberOfIterations() " << std::endl;
-    return EXIT_FAILURE;
-    }
+  const unsigned int maximumNumberOfIterations = std::stoi( argv[6] );
+  filter->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+  TEST_SET_GET_VALUE( maximumNumberOfIterations, filter->GetMaximumNumberOfIterations() );
 
   thresholder->SetInput( reader->GetOutput() );
   filter->SetInput( thresholder->GetOutput() );
   writer->SetInput( filter->GetOutput() );
-  writer->Update();
 
-  std::cout << "Class name " << filter->GetNameOfClass() << std::endl;
-  
-  filter->Print( std::cout );
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  std::cout << "Iteration used = " << filter->GetCurrentIterationNumber()     << std::endl;
-  std::cout << "Pixels changes = " << filter->GetTotalNumberOfPixelsChanged() << std::endl;
 
+  std::cout << "Iteration used = " << filter->GetCurrentIterationNumber()
+    << std::endl;
+  std::cout << "Pixels changes = " << filter->GetTotalNumberOfPixelsChanged()
+    << std::endl;
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkWeightedSumFeatureAggregatorTest1.cxx
+++ b/test/itkWeightedSumFeatureAggregatorTest1.cxx
@@ -21,15 +21,16 @@
 #include "itkLungWallFeatureGenerator.h"
 #include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkSigmoidFeatureGenerator.h"
+#include "itkTestingMacros.h"
 
 
 int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
 {
-
   if( argc < 3 )
     {
-    std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " landmarksFile inputImage outputImage ";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " landmarksFile inputImage outputImage ";
     std::cerr << " [lowerThreshold upperThreshold] " << std::endl;
     return EXIT_FAILURE;
     }
@@ -45,21 +46,13 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
-    {
-    inputImageReader->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( inputImageReader->Update() );
 
 
   using AggregatorType = itk::WeightedSumFeatureAggregator< Dimension >;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -68,7 +61,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -123,16 +116,8 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-  try 
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cerr << excp << std::endl;
-    return EXIT_FAILURE;
-    }
 
   featureAggregator->Print( std::cout );
 
@@ -141,18 +126,9 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   //
   featureAggregator->AddWeight( 13.0 );
 
-  try 
-    {
-    featureAggregator->Update();
-    std::cerr << "Failure to produce expected exception" << std::endl;
-    return EXIT_FAILURE;
-    }
-  catch( itk::ExceptionObject & excp )
-    {
-    std::cout << "Caught expected exception " << std::endl;
-    std::cout << excp << std::endl;
-    }
+  TRY_EXPECT_EXCEPTION( featureAggregator->Update() );
 
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve the code coverate of the module. Specifically:
- Prefer `std::stoi` to `atoi` and `std::stod` to `atof` due to the
  reasons stated in these topics:
  http://review.source.kitware.com/#/c/23738/
  http://review.source.kitware.com/#/c/23743/
  and
  http://review.source.kitware.com/#/c/23745/
  http://review.source.kitware.com/#/c/23746/
- Exercise basic object methods.
- Exercise the `Set`/`Get` methods and `On`/`Off` methods through the
  `TEST_SET_GET_VALUE` and `TEST_SET_GET_BOOLEAN` macros.
- Use a consistent way to display messages and check for test
  success/failure.
- Remove unnecessary input, output image and filter `std::cout` prints (the
  latter, as well as the `GetNameOfClass` method are exercised by the
   `EXERCISE_BASIC_OBJECT_METHODS`) macro.
- Some style changes for the sake of code readability and coherency across
  the toolkit tests (remove white spaces in blank lines, remove white
  spaces at the end of lines, etc.).
- Remove the ternary operator for the sake of readability, in agreement
  with the ITK Software Guide.