### PR TITLE
STYLE: Rename a class to fix a typo.

### DIFF
--- a/include/itkMorphologicalOpeningFeatureGenerator.h
+++ b/include/itkMorphologicalOpeningFeatureGenerator.h
@@ -1,7 +1,7 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    itkMorphologicalOpenningFeatureGenerator.h
+  Module:    itkMorphologicalOpeningFeatureGenerator.h
   Language:  C++
   Date:      $Date$
   Version:   $Revision$
@@ -14,8 +14,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef itkMorphologicalOpenningFeatureGenerator_h
-#define itkMorphologicalOpenningFeatureGenerator_h
+#ifndef itkMorphologicalOpeningFeatureGenerator_h
+#define itkMorphologicalOpeningFeatureGenerator_h
 
 #include "itkFeatureGenerator.h"
 #include "itkImage.h"
@@ -29,7 +29,7 @@
 namespace itk
 {
 
-/** \class MorphologicalOpenningFeatureGenerator
+/** \class MorphologicalOpeningFeatureGenerator
  * \brief Generates a feature image based on intensity and removes small pieces from it.
  *
  * This feature generator thresholds the input image, runs an Openning
@@ -43,13 +43,13 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT MorphologicalOpenningFeatureGenerator : public FeatureGenerator<NDimension>
+class ITK_TEMPLATE_EXPORT MorphologicalOpeningFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalOpenningFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalOpeningFeatureGenerator);
 
   /** Standard class type alias. */
-  using Self = MorphologicalOpenningFeatureGenerator;
+  using Self = MorphologicalOpeningFeatureGenerator;
   using Superclass = FeatureGenerator<NDimension>;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MorphologicalOpenningFeatureGenerator, FeatureGenerator);
+  itkTypeMacro(MorphologicalOpeningFeatureGenerator, FeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;
@@ -85,8 +85,8 @@ public:
   itkGetMacro( LungThreshold, InputPixelType );
 
 protected:
-  MorphologicalOpenningFeatureGenerator();
-  ~MorphologicalOpenningFeatureGenerator() override;
+  MorphologicalOpeningFeatureGenerator();
+  ~MorphologicalOpeningFeatureGenerator() override;
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
@@ -131,7 +131,7 @@ private:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-# include "itkMorphologicalOpenningFeatureGenerator.hxx"
+# include "itkMorphologicalOpeningFeatureGenerator.hxx"
 #endif
 
 #endif

--- a/include/itkMorphologicalOpeningFeatureGenerator.hxx
+++ b/include/itkMorphologicalOpeningFeatureGenerator.hxx
@@ -1,7 +1,7 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    itkMorphologicalOpenningFeatureGenerator.hxx
+  Module:    itkMorphologicalOpeningFeatureGenerator.hxx
   Language:  C++
   Date:      $Date$
   Version:   $Revision$
@@ -14,10 +14,10 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef itkMorphologicalOpenningFeatureGenerator_hxx
-#define itkMorphologicalOpenningFeatureGenerator_hxx
+#ifndef itkMorphologicalOpeningFeatureGenerator_hxx
+#define itkMorphologicalOpeningFeatureGenerator_hxx
 
-#include "itkMorphologicalOpenningFeatureGenerator.h"
+#include "itkMorphologicalOpeningFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 
@@ -28,8 +28,8 @@ namespace itk
  * Constructor
  */
 template <unsigned int NDimension>
-MorphologicalOpenningFeatureGenerator<NDimension>
-::MorphologicalOpenningFeatureGenerator()
+MorphologicalOpeningFeatureGenerator<NDimension>
+::MorphologicalOpeningFeatureGenerator()
 {
   this->SetNumberOfRequiredInputs( 1 );
   this->SetNumberOfRequiredOutputs( 1 );
@@ -56,14 +56,14 @@ MorphologicalOpenningFeatureGenerator<NDimension>
  * Destructor
  */
 template <unsigned int NDimension>
-MorphologicalOpenningFeatureGenerator<NDimension>
-::~MorphologicalOpenningFeatureGenerator()
+MorphologicalOpeningFeatureGenerator<NDimension>
+::~MorphologicalOpeningFeatureGenerator()
 {
 }
 
 template <unsigned int NDimension>
 void
-MorphologicalOpenningFeatureGenerator<NDimension>
+MorphologicalOpeningFeatureGenerator<NDimension>
 ::SetInput( const SpatialObjectType * spatialObject )
 {
   // Process object is not const-correct so the const casting is required.
@@ -71,8 +71,8 @@ MorphologicalOpenningFeatureGenerator<NDimension>
 }
 
 template <unsigned int NDimension>
-const typename MorphologicalOpenningFeatureGenerator<NDimension>::SpatialObjectType *
-MorphologicalOpenningFeatureGenerator<NDimension>
+const typename MorphologicalOpeningFeatureGenerator<NDimension>::SpatialObjectType *
+MorphologicalOpeningFeatureGenerator<NDimension>
 ::GetFeature() const
 {
   if (this->GetNumberOfOutputs() < 1)
@@ -90,7 +90,7 @@ MorphologicalOpenningFeatureGenerator<NDimension>
  */
 template <unsigned int NDimension>
 void
-MorphologicalOpenningFeatureGenerator<NDimension>
+MorphologicalOpeningFeatureGenerator<NDimension>
 ::PrintSelf(std::ostream& os, Indent indent) const
 {
   Superclass::PrintSelf( os, indent );
@@ -103,7 +103,7 @@ MorphologicalOpenningFeatureGenerator<NDimension>
  */
 template <unsigned int NDimension>
 void
-MorphologicalOpenningFeatureGenerator<NDimension>
+MorphologicalOpeningFeatureGenerator<NDimension>
 ::GenerateData()
 {
   typename InputImageSpatialObjectType::ConstPointer inputObject =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ itkMaximumFeatureAggregatorTest1.cxx
 itkMaximumFeatureAggregatorTest2.cxx
 itkMinimumFeatureAggregatorTest1.cxx
 itkMinimumFeatureAggregatorTest2.cxx
-itkMorphologicalOpenningFeatureGeneratorTest1.cxx
+itkMorphologicalOpeningFeatureGeneratorTest1.cxx
 itkRegionCompetitionImageFilterTest1.cxx
 itkRegionGrowingSegmentationModuleTest1.cxx
 itkSatoLocalStructureFeatureGeneratorTest1.cxx
@@ -185,10 +185,10 @@ itk_add_test(NAME itkLungWallFeatureGeneratorTest1
   -400.0
  )
 
-itk_add_test(NAME itkMorphologicalOpenningFeatureGeneratorTest1
-  COMMAND LesionSizingToolkitTestDriver itkMorphologicalOpenningFeatureGeneratorTest1
+itk_add_test(NAME itkMorphologicalOpeningFeatureGeneratorTest1
+  COMMAND LesionSizingToolkitTestDriver itkMorphologicalOpeningFeatureGeneratorTest1
   ${TEST_DATA_ROOT}/Input/PartSolidLesionCropped.mha
-  ${TEMP}/MorphologicalOpenningFeatureGeneratorTest1_1.mha
+  ${TEMP}/MorphologicalOpeningFeatureGeneratorTest1_1.mha
   -400.0
  )
 

--- a/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
@@ -1,7 +1,7 @@
 /*=========================================================================
 
   Program:   Lesion Sizing Toolkit
-  Module:    itkMorphologicalOpenningFeatureGeneratorTest1.cxx
+  Module:    itkMorphologicalOpeningFeatureGeneratorTest1.cxx
 
   Copyright (c) Kitware Inc. 
   All rights reserved.
@@ -13,14 +13,14 @@
 
 =========================================================================*/
 
-#include "itkMorphologicalOpenningFeatureGenerator.h"
+#include "itkMorphologicalOpeningFeatureGenerator.h"
 #include "itkImage.h"
 #include "itkSpatialObject.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int itkMorphologicalOpenningFeatureGeneratorTest1( int argc, char * argv [] )
+int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 {
 
   if( argc < 3 )
@@ -58,7 +58,7 @@ int itkMorphologicalOpenningFeatureGeneratorTest1( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  using FeatureGeneratorType = itk::MorphologicalOpenningFeatureGenerator< Dimension >;
+  using FeatureGeneratorType = itk::MorphologicalOpeningFeatureGenerator< Dimension >;
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
   FeatureGeneratorType::Pointer  featureGenerator = FeatureGeneratorType::New();


### PR DESCRIPTION
Rename the `itk::MorhologicalOpenningFeatureGenerator` class to
`itk::MorphologicalOpeningFeatureGenerator` to remove the doubled `n`.

This renaming is also in agreement with how the `*Opening*` i spelled in
ITK.