### PR TITLE
COMP: Prefer C++11 math over vcl_*

### DIFF
--- a/Examples/LesionSegmentation.cxx
+++ b/Examples/LesionSegmentation.cxx
@@ -241,7 +241,7 @@ int ViewImageAndSegmentationSurface(
   imagePlaneWidget[0]->SetKeyPressActivationValue('x');
   imagePlaneWidget[1]->SetKeyPressActivationValue('y');
   imagePlaneWidget[2]->SetKeyPressActivationValue('z');
-  
+
 
   // Set the background to something grayish
   renderer->SetBackground(0.4392, 0.5020, 0.5647);
@@ -308,7 +308,7 @@ int ViewImageAndSegmentationSurface(
     VTK_CREATE( vtkActor, outlineActor );
     outlineActor->SetMapper(outlineMapper);
     outlineActor->GetProperty()->SetColor(0,1,0);
-    renderer->AddActor(outlineActor); 
+    renderer->AddActor(outlineActor);
     }
 
   std::cout << "Bringing up visualization.." << std::endl;
@@ -318,13 +318,13 @@ int ViewImageAndSegmentationSurface(
 
     double camPos[3][3] = { {1,0,0},{0,-1,0},{0,0,-1} };
     double viewUp[3][3] = { {0,0,1},{0,0,1},{0,-1,0} };
-    
+
     for (unsigned int i = 0; i < 3; i++)
       {
       std::ostringstream os;
-      os << args.GetValueAsString("Screenshot") 
+      os << args.GetValueAsString("Screenshot")
          << "_" << i << ".png" << std::ends;
-      
+
       renderer->GetActiveCamera()->SetPosition(camPos[i]);
       renderer->GetActiveCamera()->SetFocalPoint(0,0,0);
       renderer->GetActiveCamera()->SetViewUp(viewUp[i]);

--- a/Examples/LesionSegmentationCLI.h
+++ b/Examples/LesionSegmentationCLI.h
@@ -128,7 +128,7 @@ public:
 
       if (this->GetOptionWasSet("SeedUnitsInPixels"))
         {
-        
+
         // Convert seeds from pixel units to physical units
         IndexType index = {{
           static_cast< IndexValueType >(sx),
@@ -173,7 +173,7 @@ public:
             // Loop now and check the SOP instance UID. Some datasets in the
             // biochange challenge rely on the filename, yet others rely on
             // the SOP instance UID present in the file.
-            
+
             for (std::vector< std::string >::iterator it = filesInDir.begin();
                 it != filesInDir.end(); ++it)
               {
@@ -206,7 +206,7 @@ public:
           }
         }
 
-      // Sanity check      
+      // Sanity check
       std::cout << "Seed position in physical units: (" << sx << ","
                 << sy << "," << sz << ")" << std::endl;
       InputImageType::PointType pointSeed;
@@ -221,7 +221,7 @@ public:
             indexSeed << " does not lie within the image. The images extents are"
           << this->m_Image->GetBufferedRegion() << std::endl;
         exit(-1);
-        }      
+        }
 
       seeds[i].SetPosition(sx,sy,sz);
       }

--- a/Utilities/Visualization/AntiAliasBinaryImageFilter.cxx
+++ b/Utilities/Visualization/AntiAliasBinaryImageFilter.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     std::cerr << " [RMS] [numberOfIterations]" << std::endl;
     return EXIT_FAILURE;
     }
-   
+
   const std::string inputFilename  = argv[1];
   const std::string outputFilename = argv[2];
 
@@ -73,17 +73,17 @@ int main(int argc, char* argv[])
   antiAliasFilter->SetMaximumRMSError( maximumRMSError );
   antiAliasFilter->SetNumberOfIterations( numberOfIterations );
   antiAliasFilter->SetNumberOfLayers( 3 );
-  
-  try 
+
+  try
     {
     writer->Update();
     }
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cout << "ExceptionObject caught !" << std::endl; 
-    std::cout << err << std::endl; 
+  catch( itk::ExceptionObject & err )
+    {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   std::cout << "Completed in " << antiAliasFilter->GetNumberOfIterations() << std::endl;
 

--- a/Utilities/Visualization/IsoSurfaceVolumeEstimation.cxx
+++ b/Utilities/Visualization/IsoSurfaceVolumeEstimation.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -34,7 +34,7 @@
 
 
 int main(int argc, char * argv [] )
-{  
+{
 
   if( argc < 7 )
     {
@@ -44,18 +44,18 @@ int main(int argc, char * argv [] )
     std::cerr << std::endl;
     return 1;
     }
-  
+
   VTK_CREATE( vtkMetaImageReader, imageReader );
 
   imageReader->SetFileName( argv[1] );
   imageReader->Update();
-  
+
   float isoValue = atof( argv[2] );
 
   VTK_CREATE( vtkContourFilter, contourFilter );
   VTK_CREATE( vtkCleanPolyData, cleanPolyData );
   VTK_CREATE( vtkTriangleFilter, triangleFilter );
-  contourFilter->SetValue( 0, isoValue ); 
+  contourFilter->SetValue( 0, isoValue );
 #if VTK_MAJOR_VERSION <= 5
   contourFilter->SetInput( imageReader->GetOutput() );
   cleanPolyData->SetInput( contourFilter->GetOutput() );
@@ -103,14 +103,14 @@ int main(int argc, char * argv [] )
 
   // Check if the file exists. If it does not, let's print out the axis labels
   // right at the top of the file.
-  const bool fileExists = 
+  const bool fileExists =
       vtksys::SystemTools::FileExists( outpuFileName.c_str() );
 
   ouputFile.open( outpuFileName.c_str(), std::ios_base::app );
 
   if (!fileExists)
     {
-    ouputFile << "SegmentationMethodID DatasetID ExpectedVolume ComputedVolume " 
+    ouputFile << "SegmentationMethodID DatasetID ExpectedVolume ComputedVolume "
                << "PercentError RatioOfComputedVolumeToExpectedVolume "
                << "ComputedRadius " << std::endl;
     }

--- a/Utilities/Visualization/LesionSurfaceExtraction.cxx
+++ b/Utilities/Visualization/LesionSurfaceExtraction.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -30,7 +30,7 @@
 
 
 int main(int argc, char * argv [] )
-{  
+{
 
   if( argc < 4 )
     {
@@ -39,12 +39,12 @@ int main(int argc, char * argv [] )
     std::cerr << std::endl;
     return 1;
     }
-  
+
   VTK_CREATE( vtkMetaImageReader, imageReader );
 
   imageReader->SetFileName( argv[1] );
   imageReader->Update();
-  
+
   float isoValue = atof( argv[2] );
 
   VTK_CREATE( vtkContourFilter, contourFilter );
@@ -58,7 +58,7 @@ int main(int argc, char * argv [] )
 
 
 
-  std::string surfaceFileNameExtension = 
+  std::string surfaceFileNameExtension =
     vtksys::SystemTools::GetFilenameLastExtension( argv[3] );
 
   if( surfaceFileNameExtension == ".vtk" )

--- a/Utilities/Visualization/ViewImageAndSegmentationSurface.cxx
+++ b/Utilities/Visualization/ViewImageAndSegmentationSurface.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -104,7 +104,7 @@ void ConnectPipelines(VTK_Exporter* exporter, ITK_Importer importer)
  * well.
  */
 int main(int argc, char * argv [] )
-{  
+{
 
   // Load a scalar image and a segmentation mask and display the
   // scalar image with the contours of the mask overlaid on it.
@@ -114,11 +114,11 @@ int main(int argc, char * argv [] )
     std::cerr << "Missing parameters" << std::endl;
     std::cerr << "Usage: " << argv[0] << " imageFileName maskFileName";
     std::cerr << " [isocontourValue] [representation:0=surface/1=wireframe]";
-    std::cerr << " [outputSurface.stl]"; 
+    std::cerr << " [outputSurface.stl]";
     std::cerr << std::endl;
     return 1;
     }
-  
+
   try
     {
     using PixelType = signed short;
@@ -129,7 +129,7 @@ int main(int argc, char * argv [] )
     using ImageType = itk::Image< PixelType, Dimension >;
 
     using MaskImageType = itk::Image< MaskPixelType, Dimension >;
-    
+
     using ReaderType = itk::ImageFileReader< ImageType >;
 
     using MaskReaderType = itk::ImageFileReader< MaskImageType >;
@@ -142,7 +142,7 @@ int main(int argc, char * argv [] )
     maskReader->SetFileName( argv[2] );
     maskReader->Update();
 
-    
+
     using ExportFilterType = itk::VTKImageExport< ImageType >;
     using MaskExportFilterType = itk::VTKImageExport< MaskImageType >;
 
@@ -156,13 +156,13 @@ int main(int argc, char * argv [] )
     // itk::VTKImageExport instance.
     VTK_CREATE( vtkImageImport, vtkImporter1 );
     ConnectPipelines(itkExporter1, vtkImporter1.GetPointer() );
-    
+
     VTK_CREATE( vtkImageImport, vtkImporter2 );
     ConnectPipelines(itkExporter2, vtkImporter2.GetPointer() );
-    
+
 
     vtkImporter1->Update();
-     
+
     //------------------------------------------------------------------------
     // VTK pipeline.
     //------------------------------------------------------------------------
@@ -176,7 +176,7 @@ int main(int argc, char * argv [] )
     renWin->SetSize(600, 600);
     renWin->AddRenderer(renderer);
     iren->SetRenderWindow(renWin);
-    
+
 
     // use cell picker for interacting with the image orthogonal views.
     //
@@ -186,7 +186,7 @@ int main(int argc, char * argv [] )
 
     //assign default props to the ipw's texture plane actor
     VTK_CREATE(vtkProperty , ipwProp);
-     
+
 
     // Create 3 orthogonal view using the ImagePlaneWidget
     //
@@ -242,10 +242,10 @@ int main(int argc, char * argv [] )
 
     xImagePlaneWidget->SetInteractor( iren );
     xImagePlaneWidget->On();
-     
+
     yImagePlaneWidget->SetInteractor( iren );
     yImagePlaneWidget->On();
-     
+
     zImagePlaneWidget->SetInteractor( iren );
     zImagePlaneWidget->On();
 
@@ -268,7 +268,7 @@ int main(int argc, char * argv [] )
       contourValue = atoi( argv[3] );
       }
 
-    contour->SetValue( 0, contourValue ); 
+    contour->SetValue( 0, contourValue );
 
 
     VTK_CREATE(vtkPolyDataMapper , polyMapper);
@@ -291,9 +291,9 @@ int main(int argc, char * argv [] )
     property->SetRepresentationToSurface();
 
     polyActor->SetProperty( property );
-  
+
     renderer->AddActor( polyActor );
-    
+
 
     if( argc > 4 )
       {

--- a/Utilities/Visualization/ViewImageSlicesAndSegmentationContours.cxx
+++ b/Utilities/Visualization/ViewImageSlicesAndSegmentationContours.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -38,7 +38,7 @@
   vtkSmartPointer<type> name = vtkSmartPointer<type>::New()
 
 int main(int argc, char * argv [] )
-{  
+{
 
   // Load a scalar image and a segmentation mask and display the
   // scalar image with the contours of the mask overlaid on it.
@@ -53,7 +53,7 @@ int main(int argc, char * argv [] )
     std::cerr << std::endl;
     return 1;
     }
-  
+
 
   using vtkContourVisualizationModulePointer = vtkSmartPointer< vtkContourVisualizationModule >;
   using ContoursContainer = std::vector< vtkContourVisualizationModulePointer >;
@@ -64,13 +64,13 @@ int main(int argc, char * argv [] )
   imageReader->SetFileName( argv[1] );
   imageReader->Update();
   vtkImageData * inputImage = imageReader->GetOutput();
-  
 
-  // If a landmark file is specified use that as the point to plass the slice 
+
+  // If a landmark file is specified use that as the point to plass the slice
   // around, else use the center.
 
   double seedPoint[3];
-  
+
   if (itksys::SystemTools::FileExists(argv[2]))
     {
     using SpatialObjectReaderType = itk::SpatialObjectReader< 3, unsigned short >;
@@ -101,17 +101,17 @@ int main(int argc, char * argv [] )
 
     const InputSpatialObjectType * landmarkSpatialObject = NULL;
 
-    while( spatialObjectItr != sceneChildren->end() ) 
+    while( spatialObjectItr != sceneChildren->end() )
       {
       std::string objectName = (*spatialObjectItr)->GetTypeName();
       if( objectName == "LandmarkSpatialObject" )
         {
-        landmarkSpatialObject = 
+        landmarkSpatialObject =
           dynamic_cast< const InputSpatialObjectType * >( spatialObjectItr->GetPointer() );
         }
       spatialObjectItr++;
       }
-   
+
     using PointListType = InputSpatialObjectType::PointListType;
     using SpatialObjectPointType = InputSpatialObjectType::SpatialObjectPointType;
     using PointType = SpatialObjectPointType::PointType;
@@ -177,7 +177,7 @@ int main(int argc, char * argv [] )
 
   //
   // NOTE: The following computation assumes that the ZZ component of the
-  // Direction matrix is positive.  
+  // Direction matrix is positive.
   //
   const unsigned int sliceNumber = ( seedPoint[2] - imageOrigin[2] ) / imageSpacing[2];
 
@@ -212,7 +212,7 @@ int main(int argc, char * argv [] )
     newContourModule->SetPlaneOrigin( seedPoint );
     newContourModule->SetPlaneOrientation( vtkContourVisualizationModule::SLICE_ORIENTATION_XY );
     newContourModule->SetSegmentation( segmentationReader->GetOutput() );
- 
+
     newContourModule->Update();
 
     std::cout << "Iso-value used = " << newContourModule->GetIsoValue() << std::endl;
@@ -230,7 +230,7 @@ int main(int argc, char * argv [] )
   renderer->ResetCamera();
   camera->Zoom(1.2);
 
-  if ( produceScreenshot ) 
+  if ( produceScreenshot )
     {
     VTK_CREATE( vtkWindowToImageFilter, windowToImageFilter );
     VTK_CREATE( vtkPNGWriter, screenShotWriter );
@@ -247,7 +247,7 @@ int main(int argc, char * argv [] )
     screenShotWriter->SetInputData( windowToImageFilter->GetOutput() );
 #endif
     screenShotWriter->SetFileName( screenShotFileName.c_str() );
-    
+
     renderWindow->Render();
     screenShotWriter->Write();
 

--- a/Utilities/Visualization/vtkContourVisualizationModule.cxx
+++ b/Utilities/Visualization/vtkContourVisualizationModule.cxx
@@ -1,6 +1,6 @@
 /*=========================================================================
 
-  Program:   Image Analysis Platform 
+  Program:   Image Analysis Platform
   Module:    vtkContourVisualizationModule.cxx
   Language:  C++
   Date:      $Date$
@@ -60,7 +60,7 @@ vtkContourVisualizationModule::vtkContourVisualizationModule()
   this->Property->SetColor(1.0,0.0,0.0);
   this->Actor->SetProperty( this->Property );
 
-  
+
   this->Color[0] = 1.0;
   this->Color[1] = 0.0;
   this->Color[2] = 0.0;
@@ -113,7 +113,7 @@ void vtkContourVisualizationModule::SetAutoIsoValue()
 {
   double range[2];
   this->GetScalarRange(range);
-  this->ContourFilter->SetValue( 0, (range[1] + range[0]) / 2.0 ); 
+  this->ContourFilter->SetValue( 0, (range[1] + range[0]) / 2.0 );
 }
 
 double vtkContourVisualizationModule::GetIsoValue()
@@ -126,19 +126,19 @@ void vtkContourVisualizationModule::SetContourColor( double r, double g, double 
   this->Color[0] = r;
   this->Color[1] = g;
   this->Color[2] = b;
-  
-  this->Property->SetColor( r , g , b ); 
+
+  this->Property->SetColor( r , g , b );
   this->Modified();
 }
 
 void vtkContourVisualizationModule::GetContourColor( double &r, double &g , double &b)
 {
-  r = this->Color[0]; 
+  r = this->Color[0];
   g = this->Color[1];
-  b = this->Color[2]; 
+  b = this->Color[2];
 }
 
-int vtkContourVisualizationModule::GetVisibility() 
+int vtkContourVisualizationModule::GetVisibility()
 {
   return this->Visibility;
 }
@@ -146,11 +146,11 @@ int vtkContourVisualizationModule::GetVisibility()
 void vtkContourVisualizationModule::SetContourVisibility( int state  )
 {
   this->Visibility = state;
-  this->Actor->SetVisibility( this->Visibility ); 
+  this->Actor->SetVisibility( this->Visibility );
   this->Modified();
 }
 
-vtkActor * 
+vtkActor *
 vtkContourVisualizationModule::GetActor()
 {
   return this->Actor;
@@ -166,7 +166,7 @@ void vtkContourVisualizationModule::SetPlaneOrigin( double origin[3] )
 
 void vtkContourVisualizationModule::Update()
 {
-  vtkImageData * segmentation = 
+  vtkImageData * segmentation =
     dynamic_cast<vtkImageData *>( this->ResliceFilter->GetInput() );
 
   double * segmentationOrigin  = segmentation->GetOrigin();
@@ -181,11 +181,11 @@ void vtkContourVisualizationModule::Update()
 
   int    sliceExtent[6];
 
-  sliceExtent[0] = segmentationExtent[0]; 
-  sliceExtent[1] = segmentationExtent[1]; 
-  sliceExtent[2] = segmentationExtent[2]; 
-  sliceExtent[3] = segmentationExtent[3]; 
-  sliceExtent[4] = segmentationExtent[4]; 
+  sliceExtent[0] = segmentationExtent[0];
+  sliceExtent[1] = segmentationExtent[1];
+  sliceExtent[2] = segmentationExtent[2];
+  sliceExtent[3] = segmentationExtent[3];
+  sliceExtent[4] = segmentationExtent[4];
   sliceExtent[5] = segmentationExtent[5];
 
 
@@ -218,7 +218,7 @@ void vtkContourVisualizationModule::Update()
 
   this->ResliceFilter->SetOutputSpacing( segmentation->GetSpacing() );
 
-  this->ResliceFilter->SetOutputExtent( 
+  this->ResliceFilter->SetOutputExtent(
            sliceExtent[0], sliceExtent[1],
            sliceExtent[2], sliceExtent[3],
            sliceExtent[4], sliceExtent[5] );
@@ -256,7 +256,7 @@ void vtkContourVisualizationModule::GetScalarRange(double range[2])
   range[0] = VTK_DOUBLE_MAX;
   range[1] = VTK_DOUBLE_MIN;
 
-  vtkImageData * segmentation = 
+  vtkImageData * segmentation =
     dynamic_cast<vtkImageData *>( this->ResliceFilter->GetInput() );
   if (segmentation)
     {

--- a/Utilities/Visualization/vtkContourVisualizationModule.h
+++ b/Utilities/Visualization/vtkContourVisualizationModule.h
@@ -1,6 +1,6 @@
 /*=========================================================================
 
-  Program:   Image Analysis Platform 
+  Program:   Image Analysis Platform
   Module:    vtkContourVisualizationModule.h
   Language:  C++
   Date:      $Date$
@@ -55,18 +55,18 @@ public:
   vtkActor * GetActor();
 
   // set the color of the contour
-  void SetContourColor( double r, double g, double b );  
+  void SetContourColor( double r, double g, double b );
 
   // Get contour color
-  void GetContourColor( double &r, double &g, double &b );  
+  void GetContourColor( double &r, double &g, double &b );
 
   // Set the visibility of the contour
-  void SetContourVisibility( int state );  
+  void SetContourVisibility( int state );
 
   // Get the visibility of the contour
-  int GetVisibility(); 
+  int GetVisibility();
 
-  // Get the scalar range of the input image. Returns 
+  // Get the scalar range of the input image. Returns
   // (VTK_DOUBLE_MAX, VTK_DOUBLE_MIN) if no data exists.
   void GetScalarRange(double range[2]);
 
@@ -74,7 +74,7 @@ public:
   double GetIsoValue();
 
   void SetIsoValue(double isovalue);
-  
+
   // Update the contour filter to reflect the current state
   // of the segmentation.
   void Update();

--- a/include/itkBinaryThresholdFeatureGenerator.hxx
+++ b/include/itkBinaryThresholdFeatureGenerator.hxx
@@ -66,7 +66,7 @@ BinaryThresholdFeatureGenerator<NDimension>
   // Report progress.
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
-  progress->RegisterInternalFilter( this->m_BinaryThresholdFilter, 1.0 );  
+  progress->RegisterInternalFilter( this->m_BinaryThresholdFilter, 1.0 );
 
   typename InputImageSpatialObjectType::ConstPointer inputObject =
     dynamic_cast<const InputImageSpatialObjectType * >( this->ProcessObject::GetInput(0) );

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -48,16 +48,16 @@ public:
 /** \class CannyEdgeDetectionRecursiveGaussianImageFilter
  *
  * This filter is an implementation of a Canny edge detector for scalar-valued
- * images.  Based on John Canny's paper "A Computational Approach to Edge 
- * Detection"(IEEE Transactions on Pattern Analysis and Machine Intelligence, 
- * Vol. PAMI-8, No.6, November 1986),  there are four major steps used in the 
+ * images.  Based on John Canny's paper "A Computational Approach to Edge
+ * Detection"(IEEE Transactions on Pattern Analysis and Machine Intelligence,
+ * Vol. PAMI-8, No.6, November 1986),  there are four major steps used in the
  * edge-detection scheme:
  * (1) Smooth the input image with Gaussian filter.
- * (2) Calculate the second directional derivatives of the smoothed image. 
+ * (2) Calculate the second directional derivatives of the smoothed image.
  * (3) Non-Maximum Suppression: the zero-crossings of 2nd derivative are found,
- *     and the sign of third derivative is used to find the correct extrema. 
+ *     and the sign of third derivative is used to find the correct extrema.
  * (4) The hysteresis thresholding is applied to the gradient magnitude
- *      (multiplied with zero-crossings) of the smoothed image to find and 
+ *      (multiplied with zero-crossings) of the smoothed image to find and
  *      link edges.
  *
  * \par Inputs and Outputs
@@ -69,17 +69,17 @@ public:
  * There are four parameters for this filter that control the sub-filters used
  * by the algorithm.
  *
- * \par 
+ * \par
  * Sigma is used in the Gaussian smoothing of the input image.
  * See  itkSmoothingRecursiveGaussianImageFilter for information on these
  * parameters.
  *
  * \par
- * Threshold is the lowest allowed value in the output image.  Its data type is 
+ * Threshold is the lowest allowed value in the output image.  Its data type is
  * the same as the data type of the output image. Any values below the
  * Threshold level will be replaced with the OutsideValue parameter value, whose
  * default is zero.
- * 
+ *
  * \todo Edge-linking will be added when an itk connected component labeling
  * algorithm is available.
  *
@@ -96,11 +96,11 @@ public:
   /** Standard "Self" & Superclass type alias.  */
   using Self = CannyEdgeDetectionRecursiveGaussianImageFilter;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
-   
+
   /** Image type alias support   */
   using InputImageType = TInputImage;
   using OutputImageType = TOutputImage;
-      
+
   /** SmartPointer type alias support  */
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -114,8 +114,8 @@ public:
         InputImageType, OutputImageType>;
   using ScalarRealType = typename GaussianImageFilterType::ScalarRealType;
   using SigmaArrayType = typename GaussianImageFilterType::SigmaArrayType;
-  
-  /** The default boundary condition is used unless overridden 
+
+  /** The default boundary condition is used unless overridden
    *in the Evaluate() method. */
   using DefaultBoundaryConditionType = ZeroFluxNeumannBoundaryCondition<OutputImageType>;
 
@@ -131,18 +131,18 @@ public:
   using ListPointerType = typename ListType::Pointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self);  
-    
+  itkNewMacro(Self);
+
   /** Typedef to describe the output image region type. */
   using OutputImageRegionType = typename TOutputImage::RegionType;
-    
+
   /** Run-time type information (and related methods). */
   itkTypeMacro(CannyEdgeDetectionRecursiveGaussianImageFilter, ImageToImageFilter);
-  
+
   /** ImageDimension constant    */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
-  
+
   /** Typedef of double containers */
   using ArrayType = FixedArray<double, itkGetStaticConstMacro(ImageDimension)>;
 
@@ -151,7 +151,7 @@ public:
   void SetSigma( ScalarRealType sigma );
   SigmaArrayType GetSigmaArray() const;
   ScalarRealType GetSigma() const;
-  
+
   /* Set the Threshold value for detected edges. */
   void SetThreshold(const OutputImagePixelType th)
     {
@@ -160,11 +160,11 @@ public:
     this->m_LowerThreshold = m_Threshold/2.0;
     itkLegacyReplaceBodyMacro(SetThreshold, 2.2, SetUpperThreshold);
     }
-  
+
   OutputImagePixelType GetThreshold(OutputImagePixelType itkNotUsed(th))
     {
     itkLegacyReplaceBodyMacro(GetThreshold, 2.2, GetUpperThreshold);
-    return this->m_Threshold; 
+    return this->m_Threshold;
     }
 
   ///* Set the Threshold value for detected edges. */
@@ -177,19 +177,19 @@ public:
   /* Set the Thresholdvalue for detected edges. */
   itkSetMacro(OutsideValue, OutputImagePixelType);
   itkGetMacro(OutsideValue, OutputImagePixelType);
-  
+
   OutputImageType * GetNonMaximumSuppressionImage() const
     {
     return this->m_MultiplyImageFilter->GetOutput();
     }
 
   /** CannyEdgeDetectionRecursiveGaussianImageFilter needs a larger input requested
-   * region than the output requested region ( derivative operators, etc).  
+   * region than the output requested region ( derivative operators, etc).
    * As such, CannyEdgeDetectionRecursiveGaussianImageFilter needs to provide an implementation
-   * for GenerateInputRequestedRegion() in order to inform the 
+   * for GenerateInputRequestedRegion() in order to inform the
    * pipeline execution model.
    *
-   * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */  
+   * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */
   void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
@@ -214,7 +214,7 @@ protected:
 
   void GenerateData() override;
 
-  using MultiplyImageFilterType = MultiplyImageFilter< OutputImageType, 
+  using MultiplyImageFilterType = MultiplyImageFilter< OutputImageType,
               OutputImageType, OutputImageType>;
 
 private:
@@ -237,9 +237,9 @@ private:
 
   /** Check if the index is in bounds or not */
   bool InBounds(IndexType index);
-  
 
-  /** Calculate the second derivative of the smoothed image, it writes the 
+
+  /** Calculate the second derivative of the smoothed image, it writes the
    *  result to m_UpdateBuffer using the ThreadedCompute2ndDerivative() method
    *  and multithreading mechanism.   */
   void Compute2ndDerivative();
@@ -255,37 +255,37 @@ private:
   //  virtual
   //  int SplitUpdateContainer(int i, int num, ThreadRegionType& splitRegion);
 
-  /** Does the actual work of calculating of the 2nd derivative over a region 
-   *  supplied by the multithreading mechanism.  
+  /** Does the actual work of calculating of the 2nd derivative over a region
+   *  supplied by the multithreading mechanism.
    *
    *  \sa Compute2ndDerivative
-   *  \sa Compute2ndDerivativeThreaderCallBack   */ 
+   *  \sa Compute2ndDerivativeThreaderCallBack   */
   void ThreadedCompute2ndDerivative(const OutputImageRegionType&
                                     outputRegionForThread, int threadId);
 
-  /** This callback method uses ImageSource::SplitRequestedRegion to acquire an 
+  /** This callback method uses ImageSource::SplitRequestedRegion to acquire an
    * output region that it passes to ThreadedCompute2ndDerivative for
    * processing.  */
   static ITK_THREAD_RETURN_TYPE
   Compute2ndDerivativeThreaderCallback( void * arg );
 
-  /** This methos is used to calculate the 2nd derivative for 
-   * non-boundary pixels. It is called by the ThreadedCompute2ndDerivative 
-   * method. */  
+  /** This methos is used to calculate the 2nd derivative for
+   * non-boundary pixels. It is called by the ThreadedCompute2ndDerivative
+   * method. */
   OutputImagePixelType ComputeCannyEdge(const NeighborhoodType &it,
                                         void *globalData );
 
-  /** Calculate the gradient of the second derivative of the smoothed image, 
-   *  it writes the result to m_UpdateBuffer1 using the 
+  /** Calculate the gradient of the second derivative of the smoothed image,
+   *  it writes the result to m_UpdateBuffer1 using the
    *  ThreadedCompute2ndDerivativePos() method and multithreading mechanism.
    */
   void Compute2ndDerivativePos();
 
-  /** Does the actual work of calculating of the 2nd derivative over a region 
-   *  supplied by the multithreading mechanism.  
+  /** Does the actual work of calculating of the 2nd derivative over a region
+   *  supplied by the multithreading mechanism.
    *
    *  \sa Compute2ndDerivativePos
-   *  \sa Compute3ndDerivativePosThreaderCallBack   */ 
+   *  \sa Compute3ndDerivativePosThreaderCallBack   */
   void ThreadedCompute2ndDerivativePos(const OutputImageRegionType&
                                        outputRegionForThread, int threadId);
 

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -568,7 +568,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
                     m_ComputeCannyEdge1stDerivativeOper);
         }
 
-      gradMag = vcl_sqrt((double)gradMag);
+      gradMag = std::sqrt((double)gradMag);
       derivPos = zero;
       for ( unsigned int i = 0; i < ImageDimension; i++)
         {

--- a/include/itkConfidenceConnectedSegmentationModule.hxx
+++ b/include/itkConfidenceConnectedSegmentationModule.hxx
@@ -73,9 +73,9 @@ ConfidenceConnectedSegmentationModule<NDimension>
   const FeatureImageType * featureImage = this->GetInternalFeatureImage();
 
   filter->SetInput( featureImage );
-  
+
   const InputSpatialObjectType * inputSeeds = this->GetInternalInputLandmarks();
- 
+
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
   using PointListType = typename InputSpatialObjectType::PointListType;

--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT ConnectedThresholdSegmentationModule : 
+class ITK_TEMPLATE_EXPORT ConnectedThresholdSegmentationModule :
   public RegionGrowingSegmentationModule<NDimension>
 {
 public:
@@ -78,7 +78,7 @@ protected:
 private:
   double        m_LowerThreshold;
   double        m_UpperThreshold;
-  
+
 };
 
 } // end namespace itk

--- a/include/itkConnectedThresholdSegmentationModule.hxx
+++ b/include/itkConnectedThresholdSegmentationModule.hxx
@@ -73,9 +73,9 @@ ConnectedThresholdSegmentationModule<NDimension>
   const FeatureImageType * featureImage = this->GetInternalFeatureImage();
 
   filter->SetInput( featureImage );
-  
+
   const InputSpatialObjectType * inputSeeds = this->GetInternalInputLandmarks();
- 
+
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
   using PointListType = typename InputSpatialObjectType::PointListType;

--- a/include/itkDescoteauxSheetnessFeatureGenerator.h
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.h
@@ -127,7 +127,7 @@ private:
   using EigenValueImageType = Image< EigenValueArrayType, Dimension >;
 
   using EigenAnalysisFilterType = SymmetricEigenAnalysisImageFilter< HessianImageType, EigenValueImageType >;
- 
+
   using SheetnessFilterType = DescoteauxSheetnessImageFilter< EigenValueImageType, OutputImageType >;
 
   using RescaleFilterType = RescaleIntensityImageFilter< OutputImageType, OutputImageType >;

--- a/include/itkDescoteauxSheetnessFeatureGenerator.hxx
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.hxx
@@ -102,7 +102,7 @@ void
 DescoteauxSheetnessFeatureGenerator<NDimension>
 ::GenerateData()
 {
-  typename InputImageSpatialObjectType::ConstPointer inputObject = 
+  typename InputImageSpatialObjectType::ConstPointer inputObject =
     dynamic_cast<const InputImageSpatialObjectType * >( this->ProcessObject::GetInput(0) );
 
   if( !inputObject )

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -22,14 +22,14 @@
 
 namespace itk
 {
-  
+
 /** \class DescoteauxSheetnessImageFilter
  *
  * \brief Computes a measure of Sheetness from the Hessian Eigenvalues
  *
  * Based on the "Sheetness" measure proposed by Decouteaux et. al.
- * 
- * M.Descoteaux, M.Audette, K.Chinzei, el al.: 
+ *
+ * M.Descoteaux, M.Audette, K.Chinzei, el al.:
  * "Bone enhancement filtering: Application to sinus bone segmentation
  *  and simulation of pituitary surgery."
  *  In: MICCAI.  (2005) 9-16
@@ -37,13 +37,13 @@ namespace itk
  * \ingroup IntensityImageFilters  Multithreaded
  * \ingroup LesionSizingToolkit
  */
-namespace Function {  
-  
+namespace Function {
+
 template< typename TInput, typename TOutput>
 class Sheetness
 {
 public:
-  Sheetness() 
+  Sheetness()
     {
     m_Alpha = 0.5; // suggested value in the paper
     m_Gamma = 0.5; // suggested value in the paper;
@@ -74,7 +74,7 @@ public:
     //
     // Sort the values by their absolute value.
     // At the end of the sorting we should have
-    // 
+    //
     //          l1 <= l2 <= l3
     //
     if( l2 > l3 )
@@ -95,7 +95,7 @@ public:
       double tmpa = a1;
       a1 = a2;
       a2 = tmpa;
-      }   
+      }
 
     if( l2 > l3 )
       {
@@ -106,17 +106,17 @@ public:
       a3 = a2;
       a2 = tmpa;
       }
-    
+
     if( this->m_DetectBrightSheets )
       {
-      if( a3 > 0.0 ) 
+      if( a3 > 0.0 )
         {
         return static_cast<TOutput>( sheetness );
         }
       }
     else
       {
-      if( a3 < 0.0 ) 
+      if( a3 < 0.0 )
         {
         return static_cast<TOutput>( sheetness );
         }
@@ -129,15 +129,15 @@ public:
     if( static_cast<double>( l3 ) < vnl_math::eps )
       {
       return static_cast<TOutput>( sheetness );
-      } 
+      }
 
     const double Rs = l2 / l3;
     const double Rb = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
     const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    sheetness  =         vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ); 
-    sheetness *= ( 1.0 - vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
-    sheetness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) ); 
+    sheetness  =         vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) );
+    sheetness *= ( 1.0 - vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
+    sheetness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) );
 
     return static_cast<TOutput>( sheetness );
     }
@@ -167,14 +167,14 @@ private:
   double    m_Gamma;
   double    m_C;
   bool      m_DetectBrightSheets;
-}; 
+};
 }
 
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT DescoteauxSheetnessImageFilter :
     public
-UnaryFunctorImageFilter<TInputImage,TOutputImage, 
-                        Function::Sheetness< typename TInputImage::PixelType, 
+UnaryFunctorImageFilter<TInputImage,TOutputImage,
+                        Function::Sheetness< typename TInputImage::PixelType,
                                        typename TOutputImage::PixelType>   >
 {
 public:
@@ -183,9 +183,9 @@ public:
   /** Standard class type alias. */
   using Self = DescoteauxSheetnessImageFilter;
   using Superclass = UnaryFunctorImageFilter<
-    TInputImage,TOutputImage, 
-    Function::Sheetness< 
-      typename TInputImage::PixelType, 
+    TInputImage,TOutputImage,
+    Function::Sheetness<
+      typename TInputImage::PixelType,
       typename TOutputImage::PixelType> >;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -194,7 +194,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(DescoteauxSheetnessImageFilter, 
+  itkTypeMacro(DescoteauxSheetnessImageFilter,
                UnaryFunctorImageFilter);
 
   /** Set the normalization term for sheetness */

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -133,11 +133,11 @@ public:
 
     const double Rs = l2 / l3;
     const double Rb = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
-    const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
+    const double Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    sheetness  =         vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) );
-    sheetness *= ( 1.0 - vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
-    sheetness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) );
+    sheetness  =         std::exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) );
+    sheetness *= ( 1.0 - std::exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
+    sheetness *= ( 1.0 - std::exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) );
 
     return static_cast<TOutput>( sheetness );
     }

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.hxx
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.hxx
@@ -76,7 +76,7 @@ FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule<NDimension>
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
   progress->RegisterInternalFilter( this->m_FastMarchingModule, 0.3 );
-  progress->RegisterInternalFilter( 
+  progress->RegisterInternalFilter(
       this->m_GeodesicActiveContourLevelSetModule, 0.7 );
 
   this->m_FastMarchingModule->SetInput( this->GetInput() );

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.hxx
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.hxx
@@ -76,9 +76,9 @@ FastMarchingAndShapeDetectionLevelSetSegmentationModule<NDimension>
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
   progress->RegisterInternalFilter( this->m_FastMarchingModule, 0.3 );
-  progress->RegisterInternalFilter( 
+  progress->RegisterInternalFilter(
       this->m_ShapeDetectionLevelSetModule, 0.7 );
-  
+
   this->m_FastMarchingModule->SetInput( this->GetInput() );
   this->m_FastMarchingModule->SetFeature( this->GetFeature() );
   this->m_FastMarchingModule->Update();

--- a/include/itkFastMarchingSegmentationModule.h
+++ b/include/itkFastMarchingSegmentationModule.h
@@ -29,7 +29,7 @@ namespace itk
  *
  * Takes as input a landmark spatial object and a feature image and produces as
  * output a segmentation of the output level set. Threshold this at 0 and you
- * will get the zero set. 
+ * will get the zero set.
  *
  * \ingroup SpatialObjectFilters
  * \ingroup LesionSizingToolkit

--- a/include/itkFastMarchingSegmentationModule.hxx
+++ b/include/itkFastMarchingSegmentationModule.hxx
@@ -33,11 +33,11 @@ template <unsigned int NDimension>
 FastMarchingSegmentationModule<NDimension>
 ::FastMarchingSegmentationModule()
 {
-  this->m_StoppingValue = static_cast<double>( static_cast<OutputPixelType>( 
+  this->m_StoppingValue = static_cast<double>( static_cast<OutputPixelType>(
                       NumericTraits<OutputPixelType>::max() / 2.0 ) );
 
   this->m_DistanceFromSeeds = 0.0;
-  
+
   this->SetNumberOfRequiredInputs( 2 );
   this->SetNumberOfRequiredOutputs( 1 );
 
@@ -80,7 +80,7 @@ FastMarchingSegmentationModule<NDimension>
 ::GenerateData()
 {
   using FilterType = FastMarchingImageFilter< FeatureImageType, OutputImageType >;
-  
+
   typename FilterType::Pointer filter = FilterType::New();
 
   const FeatureImageType * featureImage = this->GetInternalFeatureImage();
@@ -93,7 +93,7 @@ FastMarchingSegmentationModule<NDimension>
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
   progress->RegisterInternalFilter( filter, 0.9 );
-  
+
   const InputSpatialObjectType * inputSeeds = this->GetInternalInputLandmarks();
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
@@ -104,7 +104,7 @@ FastMarchingSegmentationModule<NDimension>
   using NodeType = typename FilterType::NodeType;
 
   typename NodeContainer::Pointer trialPoints = NodeContainer::New();
-  
+
   const PointListType & points = inputSeeds->GetPoints();
 
   IndexType index;
@@ -120,9 +120,9 @@ FastMarchingSegmentationModule<NDimension>
     // = value from the seeds. That can be seen as computing
     // a distance map from the seeds.
     node.SetValue( -this->m_DistanceFromSeeds );
-    
+
     node.SetIndex( index );
-    trialPoints->InsertElement( i, node );  
+    trialPoints->InsertElement( i, node );
     }
 
   filter->SetTrialPoints( trialPoints );
@@ -138,7 +138,7 @@ FastMarchingSegmentationModule<NDimension>
   windowing->SetOutputMinimum( -4.0 );
   windowing->SetOutputMaximum(  4.0 );
   windowing->InPlaceOn();
-  progress->RegisterInternalFilter( windowing, 0.1 );  
+  progress->RegisterInternalFilter( windowing, 0.1 );
   windowing->Update();
 
   this->PackOutputImageInOutputSpatialObject( windowing->GetOutput() );

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -26,7 +26,7 @@ namespace itk
 {
 
 /** \class FeatureAggregator
- * \brief Class for combining multiple features into a single one. 
+ * \brief Class for combining multiple features into a single one.
  *
  * This class is the base class for specific implementation of feature
  * mixing strategies.
@@ -75,7 +75,7 @@ public:
    * Method for adding a feature generator that will compute the Nth feature to
    * be passed to the segmentation module.
    */
-  void AddFeatureGenerator( FeatureGeneratorType * generator ); 
+  void AddFeatureGenerator( FeatureGeneratorType * generator );
 
   /** Check all feature generators and return consolidate MTime */
   unsigned long GetMTime() const override;

--- a/include/itkFeatureAggregator.hxx
+++ b/include/itkFeatureAggregator.hxx
@@ -136,7 +136,7 @@ FeatureAggregator<NDimension>
   while( gitr != gend )
     {
     const unsigned long t = (*gitr)->GetMTime();
-    if (t > mtime) 
+    if (t > mtime)
       {
       mtime = t;
       }

--- a/include/itkFrangiTubularnessFeatureGenerator.h
+++ b/include/itkFrangiTubularnessFeatureGenerator.h
@@ -119,7 +119,7 @@ private:
   using EigenValueImageType = Image< EigenValueArrayType, Dimension >;
 
   using EigenAnalysisFilterType = SymmetricEigenAnalysisImageFilter< HessianImageType, EigenValueImageType >;
- 
+
   using SheetnessFilterType = FrangiTubularnessImageFilter< EigenValueImageType, OutputImageType >;
 
   typename HessianFilterType::Pointer             m_HessianFilter;

--- a/include/itkFrangiTubularnessFeatureGenerator.hxx
+++ b/include/itkFrangiTubularnessFeatureGenerator.hxx
@@ -111,7 +111,7 @@ FrangiTubularnessFeatureGenerator<NDimension>
   progress->RegisterInternalFilter( this->m_EigenAnalysisFilter, .25 );
   progress->RegisterInternalFilter( this->m_SheetnessFilter, .25 );
 
-  typename InputImageSpatialObjectType::ConstPointer inputObject = 
+  typename InputImageSpatialObjectType::ConstPointer inputObject =
     dynamic_cast<const InputImageSpatialObjectType * >( this->ProcessObject::GetInput(0) );
 
   if( !inputObject )

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -22,23 +22,23 @@
 
 namespace itk
 {
-  
+
 /** \class FrangiTubularnessImageFilter
  *
  * \brief Computes a measure of CrestLines from the Hessian Eigenvalues
  *
  * Based on the "Tubularness" measure proposed by Frangi et al.
- * 
+ *
  * \ingroup IntensityImageFilters  Multithreaded
  * \ingroup LesionSizingToolkit
  */
-namespace Function {  
-  
+namespace Function {
+
 template< typename TInput, typename TOutput>
 class Tubularness
 {
 public:
-  Tubularness() 
+  Tubularness()
     {
     m_Alpha  = 0.5; // suggested value in the paper
     m_Beta   = 0.5; // suggested value in the paper;
@@ -72,7 +72,7 @@ public:
   inline TOutput operator()( const TInput & A )
     {
     double tubularness = 0.0;
-    
+
     auto a1 = static_cast<double>( A[0] );
     auto a2 = static_cast<double>( A[1] );
     auto a3 = static_cast<double>( A[2] );
@@ -102,7 +102,7 @@ public:
       double tmpa = a1;
       a1 = a2;
       a2 = tmpa;
-      }   
+      }
 
     if( l2 > l3 )
       {
@@ -113,13 +113,13 @@ public:
       a3 = a2;
       a2 = tmpa;
       }
-    
+
     if( m_BrigthForeground )
       {
       //
       // Reject dark tubes and dark ridges over bright background
       //
-      if( a3 > 0.0 ) 
+      if( a3 > 0.0 )
         {
         return tubularness;
         }
@@ -129,7 +129,7 @@ public:
       //
       // Reject bright tubes and bright ridges over dark background
       //
-      if( a3 < 0.0 ) 
+      if( a3 < 0.0 )
         {
         return tubularness;
         }
@@ -145,9 +145,9 @@ public:
     const double Rb = l1 / vcl_sqrt( l2 * l3 );
     const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    tubularness  = ( 1.0 - vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); 
-    tubularness *= (       vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) ); 
-    tubularness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
+    tubularness  = ( 1.0 - vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) );
+    tubularness *= (       vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) );
+    tubularness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
 
     return static_cast<TOutput>( tubularness );
     }
@@ -175,14 +175,14 @@ private:
   double m_Beta;
   double m_Gamma;
   bool   m_BrigthForeground;
-}; 
+};
 }
 
 template <typename TInputImage, typename TOutputImage>
 class ITK_TEMPLATE_EXPORT FrangiTubularnessImageFilter :
     public
-UnaryFunctorImageFilter<TInputImage,TOutputImage, 
-                        Function::Tubularness< typename TInputImage::PixelType, 
+UnaryFunctorImageFilter<TInputImage,TOutputImage,
+                        Function::Tubularness< typename TInputImage::PixelType,
                                        typename TOutputImage::PixelType>   >
 {
 public:
@@ -191,9 +191,9 @@ public:
   /** Standard class type alias. */
   using Self = FrangiTubularnessImageFilter;
   using Superclass = UnaryFunctorImageFilter<
-    TInputImage,TOutputImage, 
-    Function::Tubularness< 
-      typename TInputImage::PixelType, 
+    TInputImage,TOutputImage,
+    Function::Tubularness<
+      typename TInputImage::PixelType,
       typename TOutputImage::PixelType> >;
   using Pointer = SmartPointer<Self>;
   using ConstPointer = SmartPointer<const Self>;
@@ -202,7 +202,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FrangiTubularnessImageFilter, 
+  itkTypeMacro(FrangiTubularnessImageFilter,
                UnaryFunctorImageFilter);
 
   /** Set the normalization term for sheetness */

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -142,12 +142,12 @@ public:
       }
 
     const double Rs = l2 / l3;
-    const double Rb = l1 / vcl_sqrt( l2 * l3 );
-    const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
+    const double Rb = l1 / std::sqrt( l2 * l3 );
+    const double Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    tubularness  = ( 1.0 - vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) );
-    tubularness *= (       vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) );
-    tubularness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
+    tubularness  = ( 1.0 - std::exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) );
+    tubularness *= (       std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) );
+    tubularness *= ( 1.0 - std::exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) );
 
     return static_cast<TOutput>( tubularness );
     }

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT GeodesicActiveContourLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT GeodesicActiveContourLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.hxx
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.hxx
@@ -84,7 +84,7 @@ GeodesicActiveContourLevelSetSegmentationModule<NDimension>
   // Progress reporting - forward events from the fast marching filter.
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
-  progress->RegisterInternalFilter( filter, 1.0 );  
+  progress->RegisterInternalFilter( filter, 1.0 );
 
   filter->Update();
 

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.hxx
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.hxx
@@ -106,9 +106,9 @@ GradientMagnitudeSigmoidFeatureGenerator<NDimension>
   // Report progress.
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
-  progress->RegisterInternalFilter( this->m_GradientFilter, 0.5 );  
-  progress->RegisterInternalFilter( this->m_SigmoidFilter, 0.5 );  
-  
+  progress->RegisterInternalFilter( this->m_GradientFilter, 0.5 );
+  progress->RegisterInternalFilter( this->m_SigmoidFilter, 0.5 );
+
   typename InputImageSpatialObjectType::ConstPointer inputObject =
     dynamic_cast<const InputImageSpatialObjectType * >( this->ProcessObject::GetInput(0) );
 

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.h
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.h
@@ -32,7 +32,7 @@ namespace itk
  *
  * The estimation of the volume is done by the equivalent of rescaling the
  * intensity range to [0:1] and then adding the contributions of all the
- * pixels. 
+ * pixels.
  *
  * The pixels size is, of course, taken into account.
  *

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.hxx
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -136,7 +136,7 @@ GrayscaleImageSegmentationVolumeEstimator<NDimension>
     }
 
   auto * outputCarrier = static_cast<RealObjectType*>(this->ProcessObject::GetOutput(0));
- 
+
   outputCarrier->Set( volumeEstimation );
 
 }

--- a/include/itkIsotropicResampler.h
+++ b/include/itkIsotropicResampler.h
@@ -90,7 +90,7 @@ private:
   using OutputImageType = Image< OutputPixelType, Dimension >;
 
   using OutputImageSpatialObjectType = ImageSpatialObject< NDimension, OutputPixelType >;
-  
+
   double    m_OutputSpacing;
 };
 

--- a/include/itkIsotropicResamplerImageFilter.hxx
+++ b/include/itkIsotropicResamplerImageFilter.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -22,7 +22,7 @@
 
 namespace itk
 {
-  
+
 template <typename TInputImage, typename TOutputImage>
 IsotropicResamplerImageFilter<TInputImage, TOutputImage>::
 IsotropicResamplerImageFilter()
@@ -34,13 +34,13 @@ IsotropicResamplerImageFilter()
   this->m_DefaultPixelValue = static_cast< OutputImagePixelType >(0.0);
   this->m_ResampleFilter = ResampleFilterType::New();
 }
-  
+
 template <typename TInputImage, typename TOutputImage>
 IsotropicResamplerImageFilter<TInputImage, TOutputImage>::
 ~IsotropicResamplerImageFilter()
 {
 }
- 
+
 template< typename TInputImage, typename TOutputImage >
 void
 IsotropicResamplerImageFilter< TInputImage, TOutputImage >
@@ -61,7 +61,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
     {
     itkExceptionMacro("Missing input image");
     }
-  
+
   const SpacingType & inputSpacing = inputImage->GetSpacing();
 
   SizeType inputSize = inputImage->GetLargestPossibleRegion().GetSize(), finalSize;
@@ -70,7 +70,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
     const double dx = inputSize[i] * inputSpacing[i] / m_OutputSpacing[i];
     finalSize[i] = static_cast<SizeValueType>( dx );
     }
-  
+
   typename TOutputImage::RegionType outputLargestPossibleRegion;
   typename TOutputImage::RegionType::IndexType index;
   index.Fill(0);
@@ -102,7 +102,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
 
   if (m_OutputSpacing == inputImage->GetSpacing())
     {
-    // No need to resample. Desiered output spacing is the same as the input 
+    // No need to resample. Desiered output spacing is the same as the input
     // spacing. Let's just graft the output and be done with it.
     this->GraftOutput( const_cast< InputImageType * >(this->GetInput()) );
     return;
@@ -139,7 +139,7 @@ IsotropicResamplerImageFilter< TInputImage, TOutputImage >
   this->m_ResampleFilter->SetSize( finalSize );
   this->m_ResampleFilter->SetInput( inputImage );
 
-  progress->RegisterInternalFilter( this->m_ResampleFilter, 1.0 );  
+  progress->RegisterInternalFilter( this->m_ResampleFilter, 1.0 );
 
   this->m_ResampleFilter->Update();
 
@@ -156,7 +156,7 @@ void IsotropicResamplerImageFilter< TInputImage,TOutputImage >
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 IsotropicResamplerImageFilter<TInputImage,TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const
 {

--- a/include/itkLandmarksReader.hxx
+++ b/include/itkLandmarksReader.hxx
@@ -80,12 +80,12 @@ LandmarksReader<NDimension>
 
   typename SpatialObjectType::Pointer landmarkSpatialObject;
 
-  while( spatialObjectItr != sceneChildren->end() ) 
+  while( spatialObjectItr != sceneChildren->end() )
     {
     std::string objectName = (*spatialObjectItr)->GetTypeName();
     if( objectName == "LandmarkSpatialObject" )
       {
-      const auto * landmarkSpatialObjectRawPointer = 
+      const auto * landmarkSpatialObjectRawPointer =
         dynamic_cast< const SpatialObjectType * >( spatialObjectItr->GetPointer() );
       landmarkSpatialObject =
         const_cast< SpatialObjectType * >( landmarkSpatialObjectRawPointer );
@@ -98,7 +98,7 @@ LandmarksReader<NDimension>
     {
     itkExceptionMacro("Input file does not contain landmarks");
     }
- 
+
   landmarkSpatialObject->DisconnectPipeline();
 
   auto * outputObject = dynamic_cast< SpatialObjectType * >(this->ProcessObject::GetOutput(0));

--- a/include/itkLesionSegmentationMethod.h
+++ b/include/itkLesionSegmentationMethod.h
@@ -84,7 +84,7 @@ public:
    * Method for adding a feature generator that will compute the Nth feature to
    * be passed to the segmentation module.
    */
-  void AddFeatureGenerator( FeatureGeneratorType * generator ); 
+  void AddFeatureGenerator( FeatureGeneratorType * generator );
 
   /** Type of the segmentation module that encapsulate the actual segmentation
    * algorithm. */
@@ -111,7 +111,7 @@ protected:
 private:
   SpatialObjectConstPointer                 m_RegionOfInterest;
   SpatialObjectConstPointer                 m_InitialSegmentation;
-  
+
   using FeatureGeneratorPointer = typename FeatureGeneratorType::Pointer;
   using FeatureGeneratorArrayType = std::vector< FeatureGeneratorPointer >;
   using FeatureGeneratorIterator = typename FeatureGeneratorArrayType::iterator;

--- a/include/itkLesionSegmentationMethod.hxx
+++ b/include/itkLesionSegmentationMethod.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -66,7 +66,7 @@ LesionSegmentationMethod<NDimension>
 template <unsigned int NDimension>
 void
 LesionSegmentationMethod<NDimension>
-::AddFeatureGenerator( FeatureGeneratorType * generator ) 
+::AddFeatureGenerator( FeatureGeneratorType * generator )
 {
   this->m_FeatureGenerators.push_back( generator );
   this->Modified();
@@ -87,7 +87,7 @@ LesionSegmentationMethod<NDimension>
   os << "Segmentation Module " << this->m_SegmentationModule.GetPointer() << std::endl;
 
   os << "Feature generators = ";
-  
+
   auto gitr = this->m_FeatureGenerators.begin();
   auto gend = this->m_FeatureGenerators.end();
 
@@ -168,13 +168,13 @@ LesionSegmentationMethod<NDimension>
     {
     if( this->m_FeatureGenerators[0]->GetFeature() )
       {
-      this->m_SegmentationModule->SetFeature( 
+      this->m_SegmentationModule->SetFeature(
         this->m_FeatureGenerators[0]->GetFeature() );
       }
     }
 }
 
- 
+
 template <unsigned int NDimension>
 void
 LesionSegmentationMethod<NDimension>
@@ -182,7 +182,7 @@ LesionSegmentationMethod<NDimension>
 {
   this->m_ProgressAccumulator->RegisterInternalFilter(
                       this->m_SegmentationModule, 0.5);
-  this->m_SegmentationModule->SetInput( this->m_InitialSegmentation ); 
+  this->m_SegmentationModule->SetInput( this->m_InitialSegmentation );
   this->m_SegmentationModule->Update();
 }
 

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -127,12 +127,12 @@ public:
     {
     if( ls <= 0.0 && lt <= ls )
       {
-      return ( 1 + vcl_pow( ls / vnl_math_abs( lt ), m_Gamma ) );
+      return ( 1 + std::pow( ls / vnl_math_abs( lt ), m_Gamma ) );
       }
     const double abslt = vnl_math_abs( lt );
     if( ls > 0.0  &&  abslt / m_Gamma > ls )
       {
-      return vcl_pow( 1 - m_Alpha * ls / vnl_math_abs( lt ), m_Gamma );
+      return std::pow( 1 - m_Alpha * ls / vnl_math_abs( lt ), m_Gamma );
       }
     return 0.0;
     }
@@ -140,7 +140,7 @@ public:
     {
     if( ls < 0.0 && lt <= ls )
       {
-      return vcl_pow( ( ls / lt ), m_Gamma );
+      return std::pow( ( ls / lt ), m_Gamma );
       }
     return 0.0;
     }

--- a/include/itkLungWallFeatureGenerator.h
+++ b/include/itkLungWallFeatureGenerator.h
@@ -27,7 +27,7 @@ namespace itk
 {
 
 /** \class LungWallFeatureGenerator
- * \brief Generates a feature image 
+ * \brief Generates a feature image
  *
  * The typical use of this class would be to generate the feature image needed
  * by a Level Set filter to internally compute its speed image. This

--- a/include/itkMaximumFeatureAggregator.h
+++ b/include/itkMaximumFeatureAggregator.h
@@ -24,7 +24,7 @@ namespace itk
 
 /** \class MaximumFeatureAggregator
  * \brief Class for combining multiple features into a single one by computing
- * the pixel-wise maximum. 
+ * the pixel-wise maximum.
  *
  * This class generates a new feature object containing an image that is
  * computed as the pixel-wise maximum of all the input feature images.

--- a/include/itkMaximumFeatureAggregator.hxx
+++ b/include/itkMaximumFeatureAggregator.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -57,7 +57,7 @@ MaximumFeatureAggregator<NDimension>
   Superclass::PrintSelf( os, indent );
 }
 
- 
+
 template <unsigned int NDimension>
 void
 MaximumFeatureAggregator<NDimension>
@@ -94,7 +94,7 @@ MaximumFeatureAggregator<NDimension>
 
     dstitr.GoToBegin();
     srcitr.GoToBegin();
-   
+
     while( !srcitr.IsAtEnd() )
       {
       if( dstitr.Get() < srcitr.Get() )

--- a/include/itkMinimumFeatureAggregator.h
+++ b/include/itkMinimumFeatureAggregator.h
@@ -24,7 +24,7 @@ namespace itk
 
 /** \class MinimumFeatureAggregator
  * \brief Class for combining multiple features into a single one by computing
- * the pixel-wise minimum. 
+ * the pixel-wise minimum.
  *
  * This class generates a new feature object containing an image that is
  * computed as the pixel-wise minimum of all the input feature images.

--- a/include/itkMinimumFeatureAggregator.hxx
+++ b/include/itkMinimumFeatureAggregator.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -57,7 +57,7 @@ MinimumFeatureAggregator<NDimension>
   Superclass::PrintSelf( os, indent );
 }
 
- 
+
 template <unsigned int NDimension>
 void
 MinimumFeatureAggregator<NDimension>
@@ -94,7 +94,7 @@ MinimumFeatureAggregator<NDimension>
 
     dstitr.GoToBegin();
     srcitr.GoToBegin();
-   
+
     while( !srcitr.IsAtEnd() )
       {
       if( dstitr.Get() > srcitr.Get() )

--- a/include/itkMorphologicalOpeningFeatureGenerator.h
+++ b/include/itkMorphologicalOpeningFeatureGenerator.h
@@ -34,7 +34,7 @@ namespace itk
  *
  * This feature generator thresholds the input image, runs an Openning
  * Mathematical Morphology Filter and then a Voting Hole Filling filter.
- * The net effect is the elimination of small islands and small holes 
+ * The net effect is the elimination of small islands and small holes
  * from the thresholded image.
  *
  * SpatialObjects are used as inputs and outputs of this class.
@@ -107,7 +107,7 @@ private:
   using ThresholdFilterPointer = typename ThresholdFilterType::Pointer;
 
   using KernelType = BinaryBallStructuringElement< InternalPixelType, Dimension >;
-  using OpenningFilterType = BinaryMorphologicalOpeningImageFilter< 
+  using OpenningFilterType = BinaryMorphologicalOpeningImageFilter<
     InternalImageType, InternalImageType, KernelType >;
   using OpenningFilterPointer = typename OpenningFilterType::Pointer;
 

--- a/include/itkMorphologicalOpenningFeatureGenerator.h
+++ b/include/itkMorphologicalOpenningFeatureGenerator.h
@@ -1,0 +1,138 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    itkMorphologicalOpenningFeatureGenerator.h
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef itkMorphologicalOpenningFeatureGenerator_h
+#define itkMorphologicalOpenningFeatureGenerator_h
+
+#include "itkFeatureGenerator.h"
+#include "itkImage.h"
+#include "itkImageSpatialObject.h"
+#include "itkBinaryThresholdImageFilter.h"
+#include "itkVotingBinaryHoleFillFloodingImageFilter.h"
+#include "itkBinaryBallStructuringElement.h"
+#include "itkBinaryMorphologicalOpeningImageFilter.h"
+#include "itkCastImageFilter.h"
+
+namespace itk
+{
+
+/** \class MorphologicalOpenningFeatureGenerator
+ * \brief Generates a feature image based on intensity and removes small pieces from it.
+ *
+ * This feature generator thresholds the input image, runs an Openning
+ * Mathematical Morphology Filter and then a Voting Hole Filling filter.
+ * The net effect is the elimination of small islands and small holes 
+ * from the thresholded image.
+ *
+ * SpatialObjects are used as inputs and outputs of this class.
+ *
+ * \ingroup SpatialObjectFilters
+ * \ingroup LesionSizingToolkit
+ */
+template <unsigned int NDimension>
+class ITK_EXPORT MorphologicalOpenningFeatureGenerator : public FeatureGenerator<NDimension>
+{
+public:
+  /** Standard class typedefs. */
+  typedef MorphologicalOpenningFeatureGenerator         Self;
+  typedef FeatureGenerator<NDimension>                  Superclass;
+  typedef SmartPointer<Self>                            Pointer;
+  typedef SmartPointer<const Self>                      ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(MorphologicalOpenningFeatureGenerator, FeatureGenerator);
+
+  /** Dimension of the space */
+  itkStaticConstMacro(Dimension, unsigned int, NDimension);
+
+  /** Type of spatialObject that will be passed as input to this
+   * feature generator. */
+  typedef signed short                                      InputPixelType;
+  typedef Image< InputPixelType, Dimension >                InputImageType;
+  typedef ImageSpatialObject< NDimension, InputPixelType >  InputImageSpatialObjectType;
+  typedef typename InputImageSpatialObjectType::Pointer     InputImageSpatialObjectPointer;
+  typedef typename Superclass::SpatialObjectType            SpatialObjectType;
+
+  /** Input data that will be used for generating the feature. */
+  using ProcessObject::SetInput;
+  void SetInput( const SpatialObjectType * input );
+  const SpatialObjectType * GetInput() const;
+
+  /** Output data that carries the feature in the form of a
+   * SpatialObject. */
+  const SpatialObjectType * GetFeature() const;
+
+  /** Set the Hounsfield Unit value to threshold the Lung. */
+  itkSetMacro( LungThreshold, InputPixelType );
+  itkGetMacro( LungThreshold, InputPixelType );
+
+protected:
+  MorphologicalOpenningFeatureGenerator();
+  virtual ~MorphologicalOpenningFeatureGenerator();
+  void PrintSelf(std::ostream& os, Indent indent) const;
+
+  /** Method invoked by the pipeline in order to trigger the computation of
+   * the segmentation. */
+  void  GenerateData ();
+
+private:
+  MorphologicalOpenningFeatureGenerator(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+
+  typedef unsigned char                               InternalPixelType;
+  typedef Image< InternalPixelType, Dimension >       InternalImageType;
+
+  typedef float                                       OutputPixelType;
+  typedef Image< OutputPixelType, Dimension >         OutputImageType;
+
+  typedef ImageSpatialObject< NDimension, OutputPixelType >  OutputImageSpatialObjectType;
+
+  typedef BinaryThresholdImageFilter<
+    InputImageType, InternalImageType >                   ThresholdFilterType;
+  typedef typename ThresholdFilterType::Pointer           ThresholdFilterPointer;
+
+  typedef BinaryBallStructuringElement< InternalPixelType, Dimension > KernelType;
+  typedef BinaryMorphologicalOpeningImageFilter< 
+    InternalImageType, InternalImageType, KernelType >    OpenningFilterType;
+  typedef typename OpenningFilterType::Pointer            OpenningFilterPointer;
+
+  typedef VotingBinaryHoleFillFloodingImageFilter<
+    InternalImageType, InternalImageType >                VotingHoleFillingFilterType;
+  typedef typename VotingHoleFillingFilterType::Pointer   VotingHoleFillingFilterPointer;
+
+  typedef CastImageFilter<
+    InternalImageType, OutputImageType >                  CastingFilterType;
+  typedef typename CastingFilterType::Pointer             CastingFilterPointer;
+
+
+  ThresholdFilterPointer                m_ThresholdFilter;
+  OpenningFilterPointer                 m_OpenningFilter;
+  VotingHoleFillingFilterPointer        m_VotingHoleFillingFilter;
+  CastingFilterPointer                  m_CastingFilter;
+
+  InputPixelType                        m_LungThreshold;
+};
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+# include "itkMorphologicalOpenningFeatureGenerator.hxx"
+#endif
+
+#endif

--- a/include/itkMorphologicalOpenningFeatureGenerator.hxx
+++ b/include/itkMorphologicalOpenningFeatureGenerator.hxx
@@ -1,7 +1,7 @@
 /*=========================================================================
 
   Program:   Insight Segmentation & Registration Toolkit
-  Module:    itkMorphologicalOpeningFeatureGenerator.hxx
+  Module:    itkMorphologicalOpenningFeatureGenerator.hxx
   Language:  C++
   Date:      $Date$
   Version:   $Revision$
@@ -14,10 +14,10 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef itkMorphologicalOpeningFeatureGenerator_hxx
-#define itkMorphologicalOpeningFeatureGenerator_hxx
+#ifndef itkMorphologicalOpenningFeatureGenerator_hxx
+#define itkMorphologicalOpenningFeatureGenerator_hxx
 
-#include "itkMorphologicalOpeningFeatureGenerator.h"
+#include "itkMorphologicalOpenningFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 
@@ -28,8 +28,8 @@ namespace itk
  * Constructor
  */
 template <unsigned int NDimension>
-MorphologicalOpeningFeatureGenerator<NDimension>
-::MorphologicalOpeningFeatureGenerator()
+MorphologicalOpenningFeatureGenerator<NDimension>
+::MorphologicalOpenningFeatureGenerator()
 {
   this->SetNumberOfRequiredInputs( 1 );
   this->SetNumberOfRequiredOutputs( 1 );
@@ -56,14 +56,14 @@ MorphologicalOpeningFeatureGenerator<NDimension>
  * Destructor
  */
 template <unsigned int NDimension>
-MorphologicalOpeningFeatureGenerator<NDimension>
-::~MorphologicalOpeningFeatureGenerator()
+MorphologicalOpenningFeatureGenerator<NDimension>
+::~MorphologicalOpenningFeatureGenerator()
 {
 }
 
 template <unsigned int NDimension>
 void
-MorphologicalOpeningFeatureGenerator<NDimension>
+MorphologicalOpenningFeatureGenerator<NDimension>
 ::SetInput( const SpatialObjectType * spatialObject )
 {
   // Process object is not const-correct so the const casting is required.
@@ -71,13 +71,13 @@ MorphologicalOpeningFeatureGenerator<NDimension>
 }
 
 template <unsigned int NDimension>
-const typename MorphologicalOpeningFeatureGenerator<NDimension>::SpatialObjectType *
-MorphologicalOpeningFeatureGenerator<NDimension>
+const typename MorphologicalOpenningFeatureGenerator<NDimension>::SpatialObjectType *
+MorphologicalOpenningFeatureGenerator<NDimension>
 ::GetFeature() const
 {
   if (this->GetNumberOfOutputs() < 1)
     {
-    return nullptr;
+    return 0;
     }
 
   return static_cast<const SpatialObjectType*>(this->ProcessObject::GetOutput(0));
@@ -90,7 +90,7 @@ MorphologicalOpeningFeatureGenerator<NDimension>
  */
 template <unsigned int NDimension>
 void
-MorphologicalOpeningFeatureGenerator<NDimension>
+MorphologicalOpenningFeatureGenerator<NDimension>
 ::PrintSelf(std::ostream& os, Indent indent) const
 {
   Superclass::PrintSelf( os, indent );
@@ -103,7 +103,7 @@ MorphologicalOpeningFeatureGenerator<NDimension>
  */
 template <unsigned int NDimension>
 void
-MorphologicalOpeningFeatureGenerator<NDimension>
+MorphologicalOpenningFeatureGenerator<NDimension>
 ::GenerateData()
 {
   typename InputImageSpatialObjectType::ConstPointer inputObject =
@@ -150,7 +150,7 @@ MorphologicalOpeningFeatureGenerator<NDimension>
   ballSize.Fill( 1 );
   ball.SetRadius( ballSize );
   ball.CreateStructuringElement();
-
+   
   this->m_OpenningFilter->SetKernel( ball );
   this->m_OpenningFilter->SetBackgroundValue( 0 );
   this->m_OpenningFilter->SetForegroundValue( 1 );
@@ -170,7 +170,8 @@ MorphologicalOpeningFeatureGenerator<NDimension>
 
   outputImage->DisconnectPipeline();
 
-  auto * outputObject = dynamic_cast< OutputImageSpatialObjectType * >(this->ProcessObject::GetOutput(0));
+  OutputImageSpatialObjectType * outputObject =
+    dynamic_cast< OutputImageSpatialObjectType * >(this->ProcessObject::GetOutput(0));
 
   outputObject->SetImage( outputImage );
 }

--- a/include/itkRegionGrowingSegmentationModule.hxx
+++ b/include/itkRegionGrowingSegmentationModule.hxx
@@ -138,7 +138,7 @@ RegionGrowingSegmentationModule<NDimension>
   using IteratorType = ImageRegionIterator< OutputImageType >;
 
   IteratorType itr( image, image->GetBufferedRegion() );
-  
+
   itr.GoToBegin();
 
   //

--- a/include/itkSatoVesselnessFeatureGenerator.h
+++ b/include/itkSatoVesselnessFeatureGenerator.h
@@ -30,7 +30,7 @@ namespace itk
 
 /** \class SatoVesselnessFeatureGenerator
  * \brief Generates a feature image by computing the Sato Vesselness measure of
- * the input image. 
+ * the input image.
  *
  * The typical use of this class would be to generate the Vesselness-map needed
  * by a Level Set filter to internally compute its speed image.

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.hxx
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.hxx
@@ -79,11 +79,11 @@ SatoVesselnessSigmoidFeatureGenerator<NDimension>
   // from 0, but that's ok. :)
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
-  progress->RegisterInternalFilter( this->m_SigmoidFilter, 1.0 ); 
+  progress->RegisterInternalFilter( this->m_SigmoidFilter, 1.0 );
 
   //
   // Take the output of the superclass, and do further processing on it.
-  // 
+  //
   typename OutputImageSpatialObjectType::Pointer outputObject =
     dynamic_cast<OutputImageSpatialObjectType * >( this->GetInternalFeature() );
 

--- a/include/itkSegmentationVolumeEstimator.hxx
+++ b/include/itkSegmentationVolumeEstimator.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -54,7 +54,7 @@ SegmentationVolumeEstimator<NDimension>
  * Return the value of the estimated volume
  */
 template <unsigned int NDimension>
-typename SegmentationVolumeEstimator<NDimension>::RealType 
+typename SegmentationVolumeEstimator<NDimension>::RealType
 SegmentationVolumeEstimator<NDimension>
 ::GetVolume() const
 {
@@ -67,7 +67,7 @@ SegmentationVolumeEstimator<NDimension>
  * that can be passed down a pipeline.
  */
 template <unsigned int NDimension>
-const typename SegmentationVolumeEstimator<NDimension>::RealObjectType * 
+const typename SegmentationVolumeEstimator<NDimension>::RealObjectType *
 SegmentationVolumeEstimator<NDimension>
 ::GetVolumeOutput() const
 {

--- a/include/itkShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.h
@@ -33,7 +33,7 @@ namespace itk
  * \ingroup LesionSizingToolkit
  */
 template <unsigned int NDimension>
-class ITK_TEMPLATE_EXPORT ShapeDetectionLevelSetSegmentationModule : 
+class ITK_TEMPLATE_EXPORT ShapeDetectionLevelSetSegmentationModule :
   public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:

--- a/include/itkSigmoidFeatureGenerator.hxx
+++ b/include/itkSigmoidFeatureGenerator.hxx
@@ -96,7 +96,7 @@ SigmoidFeatureGenerator<NDimension>
   // Report progress.
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
   progress->SetMiniPipelineFilter(this);
-  progress->RegisterInternalFilter( this->m_SigmoidFilter, 1.0 );  
+  progress->RegisterInternalFilter( this->m_SigmoidFilter, 1.0 );
 
   typename InputImageSpatialObjectType::ConstPointer inputObject =
     dynamic_cast<const InputImageSpatialObjectType * >( this->ProcessObject::GetInput(0) );

--- a/include/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.h
@@ -104,7 +104,7 @@ public:
   itkSetMacro( InvertOutputIntensities, bool );
   itkGetMacro( InvertOutputIntensities, bool );
   itkBooleanMacro( InvertOutputIntensities );
-  
+
 protected:
   SinglePhaseLevelSetSegmentationModule();
   ~SinglePhaseLevelSetSegmentationModule() override;

--- a/include/itkSinglePhaseLevelSetSegmentationModule.hxx
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.hxx
@@ -97,7 +97,7 @@ SinglePhaseLevelSetSegmentationModule<NDimension>
     {
     return this->m_ZeroSetInputImage;
     }
-  
+
   return nullptr;
 }
 
@@ -140,8 +140,8 @@ SinglePhaseLevelSetSegmentationModule<NDimension>
     typename RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
     rescaler->SetInput( outputImage );
     rescaler->SetWindowMinimum( calculator->GetMinimum() );
-    rescaler->SetWindowMaximum( calculator->GetMaximum() ); 
-    rescaler->SetOutputMinimum(  4.0 ); // Note that the values must be [4:-4] here to 
+    rescaler->SetWindowMaximum( calculator->GetMaximum() );
+    rescaler->SetOutputMinimum(  4.0 ); // Note that the values must be [4:-4] here to
     rescaler->SetOutputMaximum( -4.0 ); // make sure that we invert and not just rescale.
     rescaler->InPlaceOn();
     rescaler->Update();

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
@@ -520,9 +520,9 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
       ev[1] = ES.get_eigenvalue(1);
       ev[2] = ES.get_eigenvalue(2);
 
-      if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
-      if ( vcl_abs(ev[1]) > vcl_abs(ev[2])  ) std::swap(ev[1], ev[2]);
-      if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
+      if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
+      if ( std::abs(ev[1]) > std::abs(ev[2])  ) std::swap(ev[1], ev[2]);
+      if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
 
       const Precision vesselness = VesselnessFunction3D(ev[0],ev[1],ev[2]);
 
@@ -564,13 +564,13 @@ VesselEnhancingDiffusion3DImageFilter<PixelType,NDimension>
     const Precision vc2= 2.0*m_Gamma*m_Gamma;
 
     const Precision   Ra2 = (l2 * l2) / (l3 * l3);
-    const Precision   Rb2 = (l1 * l1) / vcl_abs(l2 * l3);
+    const Precision   Rb2 = (l1 * l1) / std::abs(l2 * l3);
     const Precision   S2 =  (l1 * l1) + (l2 *l2) + (l3 * l3);
-    const Precision   T = vcl_exp(-(2*smoothC*smoothC)/(vcl_abs(l2)*l3*l3));
+    const Precision   T = std::exp(-(2*smoothC*smoothC)/(std::abs(l2)*l3*l3));
 
-    vesselness = T * (1.0 - vcl_exp( - Ra2/va2)) *
-      vcl_exp(-Rb2/vb2) *
-      (1.0 - vcl_exp(-S2/vc2));
+    vesselness = T * (1.0 - std::exp( - Ra2/va2)) *
+      std::exp(-Rb2/vb2) *
+      (1.0 - std::exp(-S2/vc2));
 
     }
 
@@ -614,18 +614,18 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
     ev[1] = ES.get_eigenvalue(1);
     ev[2] = ES.get_eigenvalue(2);
 
-    if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
-    if ( vcl_abs(ev[1]) > vcl_abs(ev[2])  ) std::swap(ev[1], ev[2]);
-    if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
+    if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
+    if ( std::abs(ev[1]) > std::abs(ev[2])  ) std::swap(ev[1], ev[2]);
+    if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
 
     const Precision V=VesselnessFunction3D(ev[0],ev[1],ev[2]);
     vnl_vector<Precision> evn(3);
 
     // adjusting eigenvalues
     // static_cast required to prevent error with gcc 4.1.2
-    evn[0]   = 1.0 + (m_Epsilon - 1.0) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
-    evn[1]   = 1.0 + (m_Epsilon - 1.0) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
-    evn[2]   = 1.0 + (m_Omega - 1.0 ) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[0]   = 1.0 + (m_Epsilon - 1.0) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[1]   = 1.0 + (m_Epsilon - 1.0) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[2]   = 1.0 + (m_Omega - 1.0 ) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
 
     vnl_matrix<Precision> LAM(3,3);
     LAM.fill(0);

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -25,15 +25,15 @@
 namespace itk
 {
 
-/** \class VotingBinaryHoleFillFloodingImageFilter 
+/** \class VotingBinaryHoleFillFloodingImageFilter
  *
  * \brief Perform front-propagation under a quorum sensing (voting) algorithm
  * for filling holes in a binary mask.
- * 
+ *
  * This is an alternative implementation of the
  * VotingBinaryIterativeHoleFillingImageFilter.
  *
- * \ingroup RegionGrowingSegmentation 
+ * \ingroup RegionGrowingSegmentation
  * \ingroup LesionSizingToolkit
  */
 template <typename TInputImage, typename TOutputImage>
@@ -58,18 +58,18 @@ public:
   using InputImageType = typename Superclass::InputImageType;
   using InputImagePointer = typename InputImageType::Pointer;
   using InputImageConstPointer = typename InputImageType::ConstPointer;
-  using InputImageRegionType = typename InputImageType::RegionType; 
-  using InputImagePixelType = typename InputImageType::PixelType; 
+  using InputImageRegionType = typename InputImageType::RegionType;
+  using InputImagePixelType = typename InputImageType::PixelType;
   using IndexType = typename InputImageType::IndexType;
   using OffsetValueType = typename InputImageType::OffsetValueType;
-  
+
   using OutputImageType = typename Superclass::OutputImageType;
   using OutputImagePointer = typename OutputImageType::Pointer;
-  using OutputImageRegionType = typename OutputImageType::RegionType; 
-  using OutputImagePixelType = typename OutputImageType::PixelType; 
-  
+  using OutputImageRegionType = typename OutputImageType::RegionType;
+  using OutputImagePixelType = typename OutputImageType::PixelType;
+
   using InputSizeType = typename Superclass::InputSizeType;
-  
+
   /** Image dimension constants */
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
@@ -79,7 +79,7 @@ public:
    * neighborhood of a pixel has 124 pixels (excluding itself), the 50% will be
    * 62, and if you set upd a Majority threshold of 5, that means that the
    * filter will require 67 or more neighbor pixels to be ON in order to switch
-   * the current OFF pixel to ON. The default value is 1. */ 
+   * the current OFF pixel to ON. The default value is 1. */
   itkGetConstReferenceMacro( MajorityThreshold, unsigned int );
   itkSetMacro( MajorityThreshold, unsigned int );
 
@@ -111,7 +111,7 @@ protected:
   ~VotingBinaryHoleFillFloodingImageFilter() override;
 
   void GenerateData() override;
-  
+
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
@@ -132,7 +132,7 @@ private:
   void ClearSecondSeedArray();
 
   bool TestForQuorumAtCurrentPixel() const;
- 
+
   void PutCurrentPixelNeighborsIntoSeedArray();
 
   void ComputeArrayOfNeighborhoodBufferOffsets();
@@ -152,7 +152,7 @@ private:
   SeedArrayType *                   m_SeedArray2;
 
   InputImageRegionType              m_InternalRegion;
-  
+
   using SeedNewValuesArrayType = std::vector<OutputImagePixelType>;
 
   SeedNewValuesArrayType            m_SeedsNewValues;
@@ -161,22 +161,22 @@ private:
   unsigned int                      m_MaximumNumberOfIterations;
   unsigned int                      m_NumberOfPixelsChangedInLastIteration;
   unsigned int                      m_TotalNumberOfPixelsChanged;
-  
+
   IndexType                         m_CurrentPixelIndex;
 
   //
   // Variables used for addressing the Neighbors.
   // This could be factorized into a helper class.
   //
-  OffsetValueType                   m_OffsetTable[ InputImageDimension + 1 ]; 
-  
+  OffsetValueType                   m_OffsetTable[ InputImageDimension + 1 ];
+
   using NeighborOffsetArrayType = std::vector< OffsetValueType >;
 
   NeighborOffsetArrayType           m_NeighborBufferOffset;
 
 
   //
-  // Helper cache variables 
+  // Helper cache variables
   //
   const InputImageType *            m_InputImage;
   OutputImageType *                 m_OutputImage;

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -74,7 +74,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage, TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::GenerateData()
 {
@@ -88,7 +88,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::IterateFrontPropagations()
 {
@@ -98,15 +98,15 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
   // Progress reporting
   ProgressReporter progress(this, 0, m_MaximumNumberOfIterations, 100000);
-  
-  while( this->m_CurrentIterationNumber < this->m_MaximumNumberOfIterations ) 
+
+  while( this->m_CurrentIterationNumber < this->m_MaximumNumberOfIterations )
     {
     this->VisitAllSeedsAndTransitionTheirState();
     this->m_CurrentIterationNumber++;
-    
+
     progress.CompletedPixel();   // not really a pixel but an iteration
     this->InvokeEvent( IterationEvent() );
-    
+
     if( this->m_NumberOfPixelsChangedInLastIteration ==  0 )
       {
       break;
@@ -116,7 +116,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::AllocateOutputImageWorkingMemory()
 {
@@ -134,9 +134,9 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
   this->m_SeedsMask->FillBuffer( 0 );
 }
 
- 
+
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::InitializeNeighborhood()
 {
@@ -145,7 +145,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::FindAllPixelsInTheBoundaryAndAddThemAsSeeds()
 {
@@ -156,7 +156,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
   ConstNeighborhoodIterator< InputImageType >   bit;
   ImageRegionIterator< OutputImageType >        itr;
   ImageRegionIterator< SeedMaskImageType >      mtr;
-  
+
   const InputSizeType & radius = this->GetRadius();
 
   // Find the data-set boundary "faces"
@@ -168,11 +168,11 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
   // Process only the internal face
   fit = faceList.begin();
-  
+
   this->m_InternalRegion = *fit;
 
   // Mark all the pixels in the boundary of the seed image as visited
-  using ExclusionIteratorType = itk::ImageRegionExclusionIteratorWithIndex< 
+  using ExclusionIteratorType = itk::ImageRegionExclusionIteratorWithIndex<
     SeedMaskImageType >;
   ExclusionIteratorType exIt( this->m_SeedsMask, region );
   exIt.SetExclusionRegion( this->m_InternalRegion );
@@ -188,12 +188,12 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
   bit.GoToBegin();
   itr.GoToBegin();
   mtr.GoToBegin();
-  
+
   unsigned int neighborhoodSize = bit.Size();
 
   const InputImagePixelType foregroundValue = this->GetForegroundValue();
   const InputImagePixelType backgroundValue = this->GetBackgroundValue();
-  
+
   this->m_SeedArray1->clear();
   this->m_SeedsNewValues.clear();
 
@@ -208,7 +208,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
       {
       itr.Set( backgroundValue );
       mtr.Set( 0 );
-      
+
       // Search for foreground pixels in the neighborhood
       for (unsigned int i = 0; i < neighborhoodSize; ++i)
         {
@@ -219,17 +219,17 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
           break;
           }
         }
-      }   
+      }
     ++bit;
     ++itr;
     ++mtr;
     }
-  this->m_SeedsNewValues.reserve( this->m_SeedArray1->size() ); 
+  this->m_SeedsNewValues.reserve( this->m_SeedArray1->size() );
 }
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::VisitAllSeedsAndTransitionTheirState()
 {
@@ -263,7 +263,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
     }
 
   this->PasteNewSeedValuesToOutputImage();
-   
+
   this->m_TotalNumberOfPixelsChanged += this->m_NumberOfPixelsChangedInLastIteration;
 
   // Now that the values have been copied to the output image, we can empty the
@@ -276,7 +276,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::PasteNewSeedValuesToOutputImage()
 {
@@ -300,7 +300,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::SwapSeedArrays()
 {
@@ -311,7 +311,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ClearSecondSeedArray()
 {
@@ -321,7 +321,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-bool 
+bool
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::TestForQuorumAtCurrentPixel() const
 {
@@ -337,7 +337,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
   unsigned int numberOfNeighborsAtForegroundValue = 0;
 
   //
-  // From that buffer position, visit all other neighbor pixels 
+  // From that buffer position, visit all other neighbor pixels
   // and check if they are set to the foreground value.
   //
   auto neighborItr = this->m_NeighborBufferOffset.begin();
@@ -363,7 +363,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::PutCurrentPixelNeighborsIntoSeedArray()
 {
@@ -424,7 +424,7 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ComputeArrayOfNeighborhoodBufferOffsets()
 {
@@ -466,14 +466,14 @@ VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 }
 
 template <typename TInputImage, typename TOutputImage>
-void 
+void
 VotingBinaryHoleFillFloodingImageFilter<TInputImage,TOutputImage>
 ::ComputeBirthThreshold()
 {
   const unsigned int neighborhoodSize = this->GetNeighborhoodSize();
 
   // Take the number of neighbors, discount the central pixel, and take half of them.
-  auto threshold = static_cast<unsigned int>( (neighborhoodSize - 1 ) / 2.0 ); 
+  auto threshold = static_cast<unsigned int>( (neighborhoodSize - 1 ) / 2.0 );
 
   // add the majority threshold.
   threshold += this->GetMajorityThreshold();

--- a/include/itkWeightedSumFeatureAggregator.hxx
+++ b/include/itkWeightedSumFeatureAggregator.hxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -57,7 +57,7 @@ WeightedSumFeatureAggregator<NDimension>
   Superclass::PrintSelf( os, indent );
 }
 
-  
+
 template <unsigned int NDimension>
 void
 WeightedSumFeatureAggregator<NDimension>
@@ -94,7 +94,7 @@ WeightedSumFeatureAggregator<NDimension>
 
   if( numberOfFeatures != numberOfWeights )
     {
-    itkExceptionMacro("Number of Weights " << numberOfWeights 
+    itkExceptionMacro("Number of Weights " << numberOfWeights
       << " different from " << " number of Features " << numberOfFeatures );
     }
 
@@ -102,7 +102,7 @@ WeightedSumFeatureAggregator<NDimension>
 
   for( unsigned int k = 0; k < numberOfWeights; k++ )
     {
-    sumOfWeights += this->m_Weights[k]; 
+    sumOfWeights += this->m_Weights[k];
     }
 
   for( unsigned int i = 0; i < numberOfFeatures; i++ )
@@ -119,7 +119,7 @@ WeightedSumFeatureAggregator<NDimension>
 
     dstitr.GoToBegin();
     srcitr.GoToBegin();
-   
+
     const double weight = this->m_Weights[i] / sumOfWeights;
 
     while( !srcitr.IsAtEnd() )

--- a/src/itkCannyEdgeDetectionImageFilter1.cxx
+++ b/src/itkCannyEdgeDetectionImageFilter1.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
     std::cerr << argv[0] << " inputImage outputImage [sigma upperThrehold lowerThreshold]" << std::endl;
     return EXIT_FAILURE;
     }
-   
+
   const char * inputFilename  = argv[1];
   const char * outputFilename = argv[2];
 
@@ -102,34 +102,34 @@ int main(int argc, char* argv[])
   writer->SetInput( cannyFilter->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cout << "ExceptionObject caught !" << std::endl; 
-    std::cout << err << std::endl; 
+  catch( itk::ExceptionObject & err )
+    {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   if( argc > 6 )
     {
     writer->SetInput( cannyFilter->GetNonMaximumSuppressionImage() );
     writer->SetFileName( argv[6] );
 
-    try 
+    try
       {
       writer->Update();
       }
-    catch( itk::ExceptionObject & err ) 
-      { 
-      std::cout << "ExceptionObject caught !" << std::endl; 
-      std::cout << err << std::endl; 
+    catch( itk::ExceptionObject & err )
+      {
+      std::cout << "ExceptionObject caught !" << std::endl;
+      std::cout << err << std::endl;
       return EXIT_FAILURE;
-      } 
+      }
     }
-  
+
 
   return EXIT_SUCCESS;
 }

--- a/src/itkCannyEdgeDetectionImageFilter2.cxx
+++ b/src/itkCannyEdgeDetectionImageFilter2.cxx
@@ -9,8 +9,8 @@
   Copyright (c) 2002 Insight Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
     std::cerr << argv[0] << " inputImage outputImage [sigma upperThrehold lowerThreshold]" << std::endl;
     return EXIT_FAILURE;
     }
-   
+
   const char * inputFilename  = argv[1];
   const char * outputFilename = argv[2];
 
@@ -103,34 +103,34 @@ int main(int argc, char* argv[])
   writer->SetInput( cannyFilter->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cout << "ExceptionObject caught !" << std::endl; 
-    std::cout << err << std::endl; 
+  catch( itk::ExceptionObject & err )
+    {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   if( argc > 6 )
     {
     writer->SetInput( cannyFilter->GetNonMaximumSuppressionImage() );
     writer->SetFileName( argv[6] );
 
-    try 
+    try
       {
       writer->Update();
       }
-    catch( itk::ExceptionObject & err ) 
-      { 
-      std::cout << "ExceptionObject caught !" << std::endl; 
-      std::cout << err << std::endl; 
+    catch( itk::ExceptionObject & err )
+      {
+      std::cout << "ExceptionObject caught !" << std::endl;
+      std::cout << err << std::endl;
       return EXIT_FAILURE;
-      } 
+      }
     }
-  
+
 
   return EXIT_SUCCESS;
 }

--- a/src/itkDicomSeriesReadImageWrite.cxx
+++ b/src/itkDicomSeriesReadImageWrite.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -39,7 +39,7 @@ int main( int argc, char* argv[] )
   if( argc < 3 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " DicomDirectory  outputFileName  [seriesName] [-IgnoreDirection]" 
+    std::cerr << argv[0] << " DicomDirectory  outputFileName  [seriesName] [-IgnoreDirection]"
               << std::endl;
     return EXIT_FAILURE;
     }
@@ -54,7 +54,7 @@ int main( int argc, char* argv[] )
 
   using ImageIOType = itk::GDCMImageIO;
   ImageIOType::Pointer dicomIO = ImageIOType::New();
-  
+
   reader->SetImageIO( dicomIO );
 
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
@@ -64,7 +64,7 @@ int main( int argc, char* argv[] )
   nameGenerator->AddSeriesRestriction("0008|0021" );
 
   nameGenerator->SetDirectory( argv[1] );
-  
+
   try
     {
     std::cout << std::endl << "The directory: " << std::endl;
@@ -73,9 +73,9 @@ int main( int argc, char* argv[] )
     std::cout << std::endl << std::endl;
 
     using SeriesIdContainer = std::vector< std::string >;
-    
+
     const SeriesIdContainer & seriesUID = nameGenerator->GetSeriesUIDs();
-    
+
     auto seriesItr = seriesUID.begin();
     auto seriesEnd = seriesUID.end();
     while( seriesItr != seriesEnd )
@@ -83,7 +83,7 @@ int main( int argc, char* argv[] )
       std::cout << seriesItr->c_str() << std::endl;
       seriesItr++;
       }
-  
+
 
     std::string seriesIdentifier;
     seriesIdentifier = seriesUID.begin()->c_str();
@@ -99,7 +99,7 @@ int main( int argc, char* argv[] )
     FileNamesContainer fileNames;
 
     fileNames = nameGenerator->GetFileNames( seriesIdentifier );
- 
+
     FileNamesContainer::const_iterator  fitr = fileNames.begin();
     FileNamesContainer::const_iterator  fend = fileNames.end();
 
@@ -139,7 +139,7 @@ int main( int argc, char* argv[] )
 
     using WriterType = itk::ImageFileWriter< ImageType >;
     WriterType::Pointer writer = WriterType::New();
-    
+
     writer->SetFileName( argv[2] );
     writer->UseCompressionOn();
     writer->SetInput( image );

--- a/src/itkGradientMagnitudeImageFilter.cxx
+++ b/src/itkGradientMagnitudeImageFilter.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -34,14 +34,14 @@ int main( int argc, char * argv[] )
 
   RegisterRequiredFactories();
 
-  if( argc < 3 ) 
-    { 
+  if( argc < 3 )
+    {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "  inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
     }
 
-  
+
   using InputPixelType = float;
   using OutputPixelType = float;
 
@@ -66,19 +66,19 @@ int main( int argc, char * argv[] )
   using WriterType = itk::ImageFileWriter< OutputImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( argv[2] );
- 
+
   writer->SetInput( filter->GetOutput() );
 
-  try 
+  try
     {
     writer->Update();
     }
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cout << "ExceptionObject caught !" << std::endl; 
-    std::cout << err << std::endl; 
+  catch( itk::ExceptionObject & err )
+    {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   return EXIT_SUCCESS;
 }

--- a/src/itkGradientMagnitudeRecursiveGaussianImageFilter.cxx
+++ b/src/itkGradientMagnitudeRecursiveGaussianImageFilter.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -33,8 +33,8 @@ int main( int argc, char * argv[] )
 
   RegisterRequiredFactories();
 
-  if( argc < 4 ) 
-    { 
+  if( argc < 4 )
+    {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "  inputImageFile   outputImageFile   sigma" << std::endl;
     return EXIT_FAILURE;
@@ -75,7 +75,7 @@ int main( int argc, char * argv[] )
   WriterType::Pointer writer = WriterType::New();
 
   writer->SetFileName( argv[2] );
- 
+
   writer->SetInput( filter->GetOutput() );
 
   try

--- a/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
+++ b/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -59,11 +59,11 @@ int main( int argc, char ** argv )
   using ReaderType = itk::ImageFileReader< InputImageType  >;
   using WriterType = itk::ImageFileWriter< OutputImageType >;
 
-  using FilterType = itk::RegionOfInterestImageFilter< InputImageType, 
+  using FilterType = itk::RegionOfInterestImageFilter< InputImageType,
                                             OutputImageType >;
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[3] );
@@ -100,16 +100,16 @@ int main( int argc, char ** argv )
   writer->SetInput( filter->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
-    { 
-    reader->Update(); 
-    } 
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cerr << "ExceptionObject caught !" << std::endl; 
-    std::cerr << err << std::endl; 
+  try
+    {
+    reader->Update();
+    }
+  catch( itk::ExceptionObject & err )
+    {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   const InputImageType * inputImage = reader->GetOutput();
 
@@ -137,26 +137,26 @@ int main( int argc, char ** argv )
 
   desiredRegion.SetIndex( originIndex );
   desiredRegion.SetSize( regionSize );
-  
+
   desiredRegion.PadByRadius( 2 );
 
-  desiredRegion.Crop( inputImage->GetBufferedRegion() ); 
+  desiredRegion.Crop( inputImage->GetBufferedRegion() );
 
   filter->SetRegionOfInterest( desiredRegion );
   std::cout << "Desired region: " << desiredRegion << std::endl;
   std::cout << "ImageLargestPossibleRegion: " << inputImage->GetLargestPossibleRegion() << std::endl;
   std::cout << "Seed is at : " << seedPoint << " Index: " << centralIndex << std::endl;
 
-  try 
-    { 
-    writer->Update(); 
-    } 
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cerr << "ExceptionObject caught !" << std::endl; 
-    std::cerr << err << std::endl; 
+  try
+    {
+    writer->Update();
+    }
+  catch( itk::ExceptionObject & err )
+    {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   return EXIT_SUCCESS;
 }

--- a/src/itkImageReadRegionOfInterestWrite.cxx
+++ b/src/itkImageReadRegionOfInterestWrite.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -57,7 +57,7 @@ int main( int argc, char ** argv )
   using ReaderType = itk::ImageFileReader< InputImageType  >;
   using WriterType = itk::ImageFileWriter< OutputImageType >;
 
-  using FilterType = itk::RegionOfInterestImageFilter< InputImageType, 
+  using FilterType = itk::RegionOfInterestImageFilter< InputImageType,
                                             OutputImageType >;
 
   FilterType::Pointer filter = FilterType::New();
@@ -92,16 +92,16 @@ int main( int argc, char ** argv )
   writer->SetInput( filter->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
-    { 
-    writer->Update(); 
-    } 
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cerr << "ExceptionObject caught !" << std::endl; 
-    std::cerr << err << std::endl; 
+  try
+    {
+    writer->Update();
+    }
+  catch( itk::ExceptionObject & err )
+    {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   return EXIT_SUCCESS;
 }

--- a/src/itkImageReadWrite.cxx
+++ b/src/itkImageReadWrite.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -60,16 +60,16 @@ int main( int argc, char ** argv )
   writer->SetInput( reader->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
-    { 
-    writer->Update(); 
-    } 
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cerr << "ExceptionObject caught !" << std::endl; 
-    std::cerr << err << std::endl; 
+  try
+    {
+    writer->Update();
+    }
+  catch( itk::ExceptionObject & err )
+    {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   return EXIT_SUCCESS;
 }

--- a/src/itkLaplacianRecursiveGaussianImageFilter.cxx
+++ b/src/itkLaplacianRecursiveGaussianImageFilter.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -32,8 +32,8 @@ int main( int argc, char * argv[] )
 
   RegisterRequiredFactories();
 
-  if( argc < 4 ) 
-    { 
+  if( argc < 4 )
+    {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "  inputImageFile  outputImageFile  sigma " << std::endl;
     return EXIT_FAILURE;
@@ -69,12 +69,12 @@ int main( int argc, char * argv[] )
     {
     laplacian->Update();
     }
-  catch( itk::ExceptionObject & err ) 
-    { 
-    std::cout << "ExceptionObject caught !" << std::endl; 
-    std::cout << err << std::endl; 
+  catch( itk::ExceptionObject & err )
+    {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
 
   using WriterType = itk::ImageFileWriter< OutputImageType >;
 

--- a/test/LandmarkSpatialObjectWriterTest.cxx
+++ b/test/LandmarkSpatialObjectWriterTest.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -64,8 +64,8 @@ int LandmarkSpatialObjectWriterTest( int itkNotUsed(argc), char * argv [] )
   writer->SetBinaryPoints(false);
 
   writer->Update();
-  
+
   std::cout << " [TEST DONE]" << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
+++ b/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkBinaryThresholdFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = BinaryThresholdFeatureGeneratorType::SpatialObjectType;
 
   BinaryThresholdFeatureGeneratorType::Pointer  featureGenerator = BinaryThresholdFeatureGeneratorType::New();
-  
+
   std::cout << featureGenerator->GetNameOfClass() << std::endl;
   featureGenerator->Print( std::cout );
 
@@ -95,7 +95,7 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
   std::cout << featureGenerator->GetNameOfClass() << std::endl;
   featureGenerator->Print( std::cout );
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -108,7 +108,7 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -120,7 +120,7 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -135,6 +135,6 @@ int itkBinaryThresholdFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -47,7 +47,7 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -61,7 +61,7 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = CannyEdgesDistanceFeatureGeneratorType::SpatialObjectType;
 
   CannyEdgesDistanceFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesDistanceFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -122,7 +122,7 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
     featureGenerator->SetLowerThreshold( atof( argv[5] ) );
     }
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -135,7 +135,7 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -147,7 +147,7 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -162,6 +162,6 @@ int itkCannyEdgesDistanceFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkCannyEdgesFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkCannyEdgesFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -47,7 +47,7 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -61,7 +61,7 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = CannyEdgesFeatureGeneratorType::SpatialObjectType;
 
   CannyEdgesFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -122,7 +122,7 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
     featureGenerator->SetLowerThreshold( atof( argv[5] ) );
     }
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -135,7 +135,7 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -147,7 +147,7 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -162,6 +162,6 @@ int itkCannyEdgesFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
+++ b/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkConfidenceConnectedSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -44,7 +44,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
   using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -54,7 +54,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 
   featureReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     featureReader->Update();
     }
@@ -66,7 +66,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -93,7 +93,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -103,7 +103,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
-  try 
+  try
     {
     writer->Update();
     }
@@ -115,7 +115,7 @@ int itkConfidenceConnectedSegmentationModuleTest1( int argc, char * argv [] )
 
   segmentationModule->Print( std::cout );
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   //
   // Exerciser Get methods
   //

--- a/test/itkConnectedThresholdSegmentationModuleTest1.cxx
+++ b/test/itkConnectedThresholdSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkConnectedThresholdSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -44,17 +44,17 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
   landmarksReader->Update();
- 
+
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
 
   featureReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     featureReader->Update();
     }
@@ -66,7 +66,7 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
 
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -120,7 +120,7 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -131,7 +131,7 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -145,6 +145,6 @@ int itkConnectedThresholdSegmentationModuleTest1( int argc, char * argv [] )
   segmentationModule->Print( std::cout );
 
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -41,7 +41,7 @@ int itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1( int argc, char * argv
 
   inputImageReader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -75,7 +75,7 @@ int itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1( int argc, char * argv
 
   unsigned int octave = 1;
   double smallestSigma = atof( argv[4] );
-  
+
   const unsigned int numberOfScales = atoi( argv[5] );
 
   for( unsigned int k = 0; k < numberOfScales; k++ )
@@ -107,7 +107,7 @@ int itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1( int argc, char * argv
     featureAggregator->AddFeatureGenerator( featureGenerator );
     }
 
-  try 
+  try
     {
     featureAggregator->Update();
     }
@@ -116,13 +116,13 @@ int itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1( int argc, char * argv
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
     }
- 
+
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
   using OutputImageType = AggregatorType::OutputImageType;
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -134,7 +134,7 @@ int itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1( int argc, char * argv
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
+++ b/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = DescoteauxSheetnessFeatureGeneratorType::SpatialObjectType;
 
   DescoteauxSheetnessFeatureGeneratorType::Pointer  featureGenerator = DescoteauxSheetnessFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -135,7 +135,7 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
     featureGenerator->SetNoiseNormalization( atof( argv[7] ) );
     }
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -148,7 +148,7 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -159,7 +159,7 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -173,6 +173,6 @@ int itkDescoteauxSheetnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkDescoteauxSheetnessImageFilterTest1.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkDescoteauxSheetnessImageFilterTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -45,7 +45,7 @@ int itkDescoteauxSheetnessImageFilterTest1( int argc, char * argv [] )
   using EigenValueArrayType = itk::FixedArray< double, HessianPixelType::Dimension >;
   using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter< 
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
     HessianImageType, EigenValueImageType >;
 
   using ReaderType = itk::ImageFileReader< InputImageType >;
@@ -60,7 +60,7 @@ int itkDescoteauxSheetnessImageFilterTest1( int argc, char * argv [] )
   using FilterType = itk::DescoteauxSheetnessImageFilter< EigenValueImageType, OutputImageType >;
 
   FilterType::Pointer sheetnessFilter = FilterType::New();
-  
+
   hessian->SetInput( reader->GetOutput() );
   eigen->SetInput( hessian->GetOutput() );
   sheetnessFilter->SetInput( eigen->GetOutput() );
@@ -100,7 +100,7 @@ int itkDescoteauxSheetnessImageFilterTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( sheetnessFilter->GetOutput() );
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkDescoteauxSheetnessImageFilterTest2.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest2.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkDescoteauxSheetnessImageFilterTest2.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -44,7 +44,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   using EigenValueArrayType = itk::FixedArray< double, HessianPixelType::Dimension >;
   using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter< 
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
     HessianImageType, EigenValueImageType >;
 
   using WriterType = itk::ImageFileWriter< OutputImageType >;
@@ -59,7 +59,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   spacing[0] = 0.5;
   spacing[1] = 0.5;
   spacing[2] = 0.5;
-  
+
   inputImage->SetSpacing( spacing );
 
 
@@ -101,9 +101,9 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
 
   InputImageType::IndexType firstIndex;
   firstIndex.Fill(0);
-  std::cout << "First pixel value = " << inputImage->GetPixel(firstIndex) << std::endl; 
+  std::cout << "First pixel value = " << inputImage->GetPixel(firstIndex) << std::endl;
   //
-  // Populate the inputImage with a bright XY plane  
+  // Populate the inputImage with a bright XY plane
   //
   while( !itr.IsAtEnd() )
     {
@@ -115,7 +115,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   using FilterType = itk::DescoteauxSheetnessImageFilter< EigenValueImageType, OutputImageType >;
 
   FilterType::Pointer sheetnessFilter = FilterType::New();
-  
+
   hessian->SetInput( inputImage );
   eigen->SetInput( hessian->GetOutput() );
   sheetnessFilter->SetInput( eigen->GetOutput() );
@@ -155,7 +155,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   writer->SetFileName( argv[1] );
   writer->SetInput( sheetnessFilter->GetOutput() );
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkFastMarchingSegmentationModuleTest1.cxx
+++ b/test/itkFastMarchingSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkFastMarchingSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -43,7 +43,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
   using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -52,7 +52,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
   featureReader->SetFileName( argv[2] );
-  try 
+  try
     {
     featureReader->Update();
     }
@@ -64,7 +64,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
 
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -90,7 +90,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
   OutputWriterType::Pointer writer = OutputWriterType::New();
@@ -98,7 +98,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
-  try 
+  try
     {
     writer->Update();
     }
@@ -109,7 +109,7 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
     }
 
   segmentationModule->Print( std::cout );
-  
+
 
   //
   // Exercise Set/Get methods
@@ -122,13 +122,13 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
     std::cerr << "Error in Set/GetStoppingValue() " << std::endl;
     return EXIT_FAILURE;
     }
-  
+
   if( segmentationModule->GetDistanceFromSeeds() != 0.0 )
     {
     std::cerr << "Error in Set/GetDistanceFromSeeds() " << std::endl;
     return EXIT_FAILURE;
     }
-  
+
   segmentationModule->SetStoppingValue( stoppingTime );
   segmentationModule->SetDistanceFromSeeds( distanceFromSeeds );
 
@@ -137,12 +137,12 @@ int itkFastMarchingSegmentationModuleTest1( int argc, char * argv [] )
     std::cerr << "Error in Set/GetStoppingValue() " << std::endl;
     return EXIT_FAILURE;
     }
-  
+
   if( segmentationModule->GetDistanceFromSeeds() != distanceFromSeeds )
     {
     std::cerr << "Error in Set/GetDistanceFromSeeds() " << std::endl;
     return EXIT_FAILURE;
     }
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkFeatureAggregatorTest1.cxx
+++ b/test/itkFeatureAggregatorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkFeatureAggregatorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -25,7 +25,7 @@
 #include "itkSigmoidFeatureGenerator.h"
 #include "itkConnectedThresholdSegmentationModule.h"
 
-namespace itk 
+namespace itk
 {
 template< unsigned int NDimension>
 class FeatureAggregatorSurrogate : public FeatureAggregator< NDimension >
@@ -50,7 +50,7 @@ public:
 protected:
   FeatureAggregatorSurrogate() {};
   ~FeatureAggregatorSurrogate() override {};
-  void PrintSelf(std::ostream& os, Indent indent) const override 
+  void PrintSelf(std::ostream& os, Indent indent) const override
     {
     this->Superclass::PrintSelf( os, indent );
     }
@@ -98,7 +98,7 @@ private:
 
       dstitr.GoToBegin();
       srcitr.GoToBegin();
-     
+
       while( !srcitr.IsAtEnd() )
         {
         if( dstitr.Get() > srcitr.Get() )
@@ -142,7 +142,7 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -156,7 +156,7 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
   using AggregatorType = itk::FeatureAggregatorSurrogate< Dimension >;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -165,7 +165,7 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -191,12 +191,12 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   using SegmentationModuleType = itk::ConnectedThresholdSegmentationModule< Dimension >;
-  
+
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
 
 
@@ -218,14 +218,14 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
 
   featureAggregator->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = featureAggregator->GetFeature();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -238,7 +238,7 @@ int itkFeatureAggregatorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkFeatureGeneratorTest1.cxx
+++ b/test/itkFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -26,7 +26,7 @@ int itkFeatureGeneratorTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
   FeatureGeneratorType::Pointer  featureGenerator = FeatureGeneratorType::New();
-  
+
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
   ImageSpatialObjectType::Pointer inputObject = ImageSpatialObjectType::New();
@@ -39,6 +39,6 @@ int itkFeatureGeneratorTest1( int itkNotUsed(argc), char * itkNotUsed(argv) [] )
 
   featureGenerator->Print( std::cout );
 
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
+++ b/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkFrangiTubularnessFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = FrangiTubularnessFeatureGeneratorType::SpatialObjectType;
 
   FrangiTubularnessFeatureGeneratorType::Pointer  featureGenerator = FrangiTubularnessFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -95,7 +95,7 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
     }
 
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -108,7 +108,7 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -119,7 +119,7 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -134,6 +134,6 @@ int itkFrangiTubularnessFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -36,7 +36,7 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   using SegmentationModuleType = itk::GeodesicActiveContourLevelSetSegmentationModule< Dimension >;
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using InputImageType = SegmentationModuleType::InputImageType;
   using FeatureImageType = SegmentationModuleType::FeatureImageType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -51,7 +51,7 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   inputReader->SetFileName( argv[1] );
   featureReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputReader->Update();
     featureReader->Update();
@@ -75,7 +75,7 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
 
   segmentationModule->SetInput( inputObject );
   segmentationModule->SetFeature( featureObject );
-   
+
   if (argc > 4)
     {
     segmentationModule->SetAdvectionScaling( atof(argv[4]) );
@@ -99,13 +99,13 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
     segmentationModule->SetMaximumNumberOfIterations( atof(argv[7]) );
     std::cout << "Setting maximum iterations to " << atof(argv[7]) << std::endl;
     }
-  
+
   segmentationModule->Update();
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -115,7 +115,7 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -129,6 +129,6 @@ int itkGeodesicActiveContourLevelSetSegmentationModuleTest1( int argc, char * ar
   segmentationModule->Print( std::cout );
 
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -27,7 +27,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
   using VolumeEstimatorType = itk::GrayscaleImageSegmentationVolumeEstimator<Dimension>;
 
   VolumeEstimatorType::Pointer  volumeEstimator = VolumeEstimatorType::New();
-  
+
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
   ImageSpatialObjectType::Pointer inputObject = ImageSpatialObjectType::New();
@@ -57,13 +57,13 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
   volumeEstimator->SetInput( inputImageSpatialObject );
 
   inputImageSpatialObject->SetImage( image );
- 
+
   InputImageType::SpacingType spacing;
 
   spacing[0] = 0.5;
   spacing[1] = 0.5;
   spacing[2] = 0.8;
-  
+
   image->SetSpacing( spacing );
 
 
@@ -88,7 +88,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
   InputImageType::PointType point;
 
   //
-  // Populate the image with a sphere 
+  // Populate the image with a sphere
   //
   InputImageType::PointType center;
 
@@ -102,7 +102,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
     {
     index = itr.GetIndex();
     image->TransformIndexToPhysicalPoint( index, point );
-    const double distance = point.EuclideanDistanceTo( center ); 
+    const double distance = point.EuclideanDistanceTo( center );
 
     if( distance > radius )
       {
@@ -137,7 +137,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
   writer->Update();
 
   std::cout << "Class name = " << volumeEstimator->GetNameOfClass() << std::endl;
- 
+
   const double pi = atan(1.0) * 4.0;
 
   const double expectedVolume = ( 4.0 / 3.0 ) * pi * ( radius * radius * radius );

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -39,7 +39,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -84,14 +84,14 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
 
   // Check if the file exists. If it does not, let's print out the axis labels
   // right at the top of the file.
-  const bool fileExists = 
+  const bool fileExists =
       itksys::SystemTools::FileExists( outpuFileName.c_str() );
 
   ouputFile.open( outpuFileName.c_str(), std::ios_base::app );
 
   if (!fileExists)
     {
-    ouputFile << "SegmentationMethodID DatasetID ExpectedVolume ComputedVolume " 
+    ouputFile << "SegmentationMethodID DatasetID ExpectedVolume ComputedVolume "
                << "PercentError RatioOfComputedVolumeToExpectedVolume "
                << "ComputedRadius " << std::endl;
     }

--- a/test/itkLandmarksReaderTest1.cxx
+++ b/test/itkLandmarksReaderTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLandmarksReaderTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -36,7 +36,7 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
   //  Reading the landmarks file with the itkLandmarksReader.
   //
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   std::string inputFileName = argv[1];
@@ -85,17 +85,17 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
 
   const InputSpatialObjectType * landmarkSpatialObject2 = nullptr;
 
-  while( spatialObjectItr != sceneChildren->end() ) 
+  while( spatialObjectItr != sceneChildren->end() )
     {
     std::string objectName = (*spatialObjectItr)->GetTypeName();
     if( objectName == "LandmarkSpatialObject" )
       {
-      landmarkSpatialObject2 = 
+      landmarkSpatialObject2 =
         dynamic_cast< const InputSpatialObjectType * >( spatialObjectItr->GetPointer() );
       }
     spatialObjectItr++;
     }
- 
+
   using PointListType = InputSpatialObjectType::PointListType;
 
   const unsigned int numberOfPoints1 = landmarkSpatialObject1->GetNumberOfPoints();

--- a/test/itkLesionSegmentationMethodTest1.cxx
+++ b/test/itkLesionSegmentationMethodTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -26,7 +26,7 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  segmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -45,7 +45,7 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
   ImageMaskSpatialObjectType::Pointer initialSegmentation = ImageMaskSpatialObjectType::New();
 
   segmentationMethod->SetInitialSegmentation( initialSegmentation );
-  
+
   const MethodType::SpatialObjectType * initialSegmentationReturned =
     segmentationMethod->GetInitialSegmentation();
 
@@ -75,6 +75,6 @@ int itkLesionSegmentationMethodTest1( int itkNotUsed(argc), char * itkNotUsed(ar
 
   segmentationMethod->Print( std::cout );
 
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest2.cxx
+++ b/test/itkLesionSegmentationMethodTest2.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest2.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -30,7 +30,7 @@ int itkLesionSegmentationMethodTest2( int itkNotUsed(argc), char * itkNotUsed(ar
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  segmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -76,6 +76,6 @@ int itkLesionSegmentationMethodTest2( int itkNotUsed(argc), char * itkNotUsed(ar
     }
 
   segmentationMethod->Print( std::cout );
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkLesionSegmentationMethodTest3.cxx
+++ b/test/itkLesionSegmentationMethodTest3.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest3.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -47,7 +47,7 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -58,7 +58,7 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
     }
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -67,7 +67,7 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -82,7 +82,7 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
 
@@ -112,12 +112,12 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha( 100.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   using SegmentationModuleType = itk::ConnectedThresholdSegmentationModule< Dimension >;
-  
+
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
 
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
@@ -139,19 +139,19 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
   segmentationModule->SetLowerThreshold( lowerThreshold );
   segmentationModule->SetUpperThreshold( upperThreshold );
 
- 
+
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
 
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -164,7 +164,7 @@ int itkLesionSegmentationMethodTest3( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLesionSegmentationMethodTest4.cxx
+++ b/test/itkLesionSegmentationMethodTest4.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest4.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a fast marching level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationMethod.h"
@@ -53,7 +53,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -67,7 +67,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -82,10 +82,10 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
   CannyEdgesFeatureGeneratorType::Pointer  cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
- 
+
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
 
@@ -138,7 +138,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -148,14 +148,14 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
 
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -168,7 +168,7 @@ int itkLesionSegmentationMethodTest4( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLesionSegmentationMethodTest5.cxx
+++ b/test/itkLesionSegmentationMethodTest5.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest5.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -56,7 +56,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -70,7 +70,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -85,9 +85,9 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using GradientMagnitudeSigmoidGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator< Dimension >;
-  GradientMagnitudeSigmoidGeneratorType::Pointer gradientMagnitudeSigmoidGenerator = 
+  GradientMagnitudeSigmoidGeneratorType::Pointer gradientMagnitudeSigmoidGenerator =
     GradientMagnitudeSigmoidGeneratorType::New();
 
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
@@ -121,10 +121,10 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   gradientMagnitudeSigmoidGenerator->SetSigma( 1.0 );
   gradientMagnitudeSigmoidGenerator->SetAlpha( -0.1 );
   gradientMagnitudeSigmoidGenerator->SetBeta( 150.0 );
@@ -151,7 +151,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
 
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
- 
+
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using InputSegmentationType = SegmentationModuleType::InputImageType;
 
@@ -161,7 +161,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   inputSegmentationReader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     inputSegmentationReader->Update();
     }
@@ -183,14 +183,14 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
 
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -203,7 +203,7 @@ int itkLesionSegmentationMethodTest5( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLesionSegmentationMethodTest6.cxx
+++ b/test/itkLesionSegmentationMethodTest6.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest6.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a shape detection level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationMethod.h"
@@ -57,7 +57,7 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -71,7 +71,7 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -86,9 +86,9 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using GradientMagnitudeSigmoidGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator< Dimension >;
-  GradientMagnitudeSigmoidGeneratorType::Pointer gradientMagnitudeSigmoidGenerator = 
+  GradientMagnitudeSigmoidGeneratorType::Pointer gradientMagnitudeSigmoidGenerator =
     GradientMagnitudeSigmoidGeneratorType::New();
 
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
@@ -122,10 +122,10 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   gradientMagnitudeSigmoidGenerator->SetSigma( 1.0 );
   gradientMagnitudeSigmoidGenerator->SetAlpha( -0.1 );
   gradientMagnitudeSigmoidGenerator->SetBeta( 150.0 );
@@ -143,7 +143,7 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -153,14 +153,14 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
 
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -173,7 +173,7 @@ int itkLesionSegmentationMethodTest6( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLesionSegmentationMethodTest7.cxx
+++ b/test/itkLesionSegmentationMethodTest7.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest7.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a shape detection level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationMethod.h"
@@ -57,7 +57,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -71,7 +71,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -86,7 +86,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
@@ -113,7 +113,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   vesselnessGenerator->SetAlpha2( 2.0 );
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule< Dimension >;
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
   segmentationModule->SetMaximumRMSError( argc > 4 ? atof(argv[4]) : 0.0002 );
@@ -126,7 +126,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -135,14 +135,14 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
 
@@ -152,7 +152,7 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -163,12 +163,12 @@ int itkLesionSegmentationMethodTest7( int argc, char * argv [] )
     }
 
 
-  // 
+  //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
+  try
     {
     lesionSegmentationMethod->Update();
     std::cerr << "Failure to throw expected exception" << std::endl;

--- a/test/itkLesionSegmentationMethodTest8.cxx
+++ b/test/itkLesionSegmentationMethodTest8.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest8.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a shape detection level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationMethod.h"
@@ -61,7 +61,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -75,7 +75,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -90,10 +90,10 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
   CannyEdgesFeatureGeneratorType::Pointer  cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
- 
+
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
 
@@ -135,7 +135,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
                         inputImage->GetSpacing()[2] };
   double maxSpacing = (spacing[0] > spacing[1] ? spacing[0] : spacing[1]);
   maxSpacing = (maxSpacing > spacing[2] ? maxSpacing : spacing[2]);
-  
+
   cannyEdgesGenerator->SetSigma( argc > 4 ? atof(argv[4]) : maxSpacing );
   cannyEdgesGenerator->SetUpperThreshold( argc > 5 ? atof(argv[5]) : 150.0 );
   cannyEdgesGenerator->SetLowerThreshold( argc > 6 ? atof(argv[6]) :  75.0 );
@@ -152,7 +152,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -162,14 +162,14 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
 
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -182,7 +182,7 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -193,12 +193,12 @@ int itkLesionSegmentationMethodTest8( int argc, char * argv [] )
     }
 
 
-  // 
+  //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
+  try
     {
     lesionSegmentationMethod->Update();
     std::cerr << "Failure to throw expected exception" << std::endl;

--- a/test/itkLesionSegmentationMethodTest8b.cxx
+++ b/test/itkLesionSegmentationMethodTest8b.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest8b.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a shape detection level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationImageFilter8.h"
@@ -46,7 +46,7 @@ int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
   using OutputPixelType = float;
   using InputImageType = itk::Image< InputPixelType,  Dimension >;
   using OutputImageType = itk::Image< OutputPixelType, Dimension >;
-  using SegmentationMethodType = itk::LesionSegmentationImageFilter8< 
+  using SegmentationMethodType = itk::LesionSegmentationImageFilter8<
           InputImageType, OutputImageType >;
   using InputImageReaderType = itk::ImageFileReader< InputImageType >;
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
@@ -56,7 +56,7 @@ int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -88,7 +88,7 @@ int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
   segmentationMethod->SetResampleThickSliceData( resampleThickSliceData );
   segmentationMethod->SetUseVesselEnhancingDiffusion( useVesselEnhancingDiffusion );
 
-  try 
+  try
     {
     segmentationMethod->Update();
     }
@@ -103,7 +103,7 @@ int itkLesionSegmentationMethodTest8b( int argc, char * argv [] )
   writer->SetInput( segmentationMethod->GetOutput() );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLesionSegmentationMethodTest9.cxx
+++ b/test/itkLesionSegmentationMethodTest9.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLesionSegmentationMethodTest9.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -14,7 +14,7 @@
 =========================================================================*/
 
 // The test runs a shape detection level set from user supplied seed points
-// and then runs the shape detection level set with the results from the 
+// and then runs the shape detection level set with the results from the
 // fast marching to get the final segmentation.
 
 #include "itkLesionSegmentationMethod.h"
@@ -58,7 +58,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -72,7 +72,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   using MethodType = itk::LesionSegmentationMethod< Dimension >;
 
   MethodType::Pointer  lesionSegmentationMethod = MethodType::New();
-  
+
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject< Dimension >;
 
   ImageMaskSpatialObjectType::Pointer regionOfInterest = ImageMaskSpatialObjectType::New();
@@ -87,11 +87,11 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using GradientMagnitudeSigmoidFeatureGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator< Dimension >;
-  GradientMagnitudeSigmoidFeatureGeneratorType::Pointer  gradientMagnitudeSigmoidGenerator = 
+  GradientMagnitudeSigmoidFeatureGeneratorType::Pointer  gradientMagnitudeSigmoidGenerator =
     GradientMagnitudeSigmoidFeatureGeneratorType::New();
- 
+
   using FeatureAggregatorType = itk::MinimumFeatureAggregator< Dimension >;
   FeatureAggregatorType::Pointer featureAggregator = FeatureAggregatorType::New();
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
@@ -125,7 +125,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   gradientMagnitudeSigmoidGenerator->SetSigma( 1.0 );
   gradientMagnitudeSigmoidGenerator->SetAlpha( -100.0 );
   gradientMagnitudeSigmoidGenerator->SetBeta( 300 );
- 
+
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule< Dimension >;
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
   segmentationModule->SetMaximumRMSError( argc > 4 ? atof(argv[4]) : 0.0002 );
@@ -138,7 +138,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   lesionSegmentationMethod->SetSegmentationModule( segmentationModule );
 
   using LandmarksReaderType = itk::LandmarksReader< Dimension >;
-  
+
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName( argv[1] );
@@ -147,14 +147,14 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   lesionSegmentationMethod->SetInitialSegmentation( landmarksReader->GetOutput() );
   lesionSegmentationMethod->Update();
 
-  
+
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
 
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
 
@@ -164,7 +164,7 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -175,12 +175,12 @@ int itkLesionSegmentationMethodTest9( int argc, char * argv [] )
     }
 
 
-  // 
+  //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator( lungWallGenerator );
 
-  try 
+  try
     {
     lesionSegmentationMethod->Update();
     std::cerr << "Failure to throw expected exception" << std::endl;

--- a/test/itkLocalStructureImageFilterTest1.cxx
+++ b/test/itkLocalStructureImageFilterTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLocalStructureImageFilterTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -45,7 +45,7 @@ int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
   using EigenValueArrayType = itk::FixedArray< double, HessianPixelType::Dimension >;
   using EigenValueImageType = itk::Image< EigenValueArrayType, Dimension >;
 
-  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter< 
+  using EigenAnalysisFilterType = itk::SymmetricEigenAnalysisImageFilter<
     HessianImageType, EigenValueImageType >;
 
   using ReaderType = itk::ImageFileReader< InputImageType >;
@@ -60,7 +60,7 @@ int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
   using LocalStructureFilterType = itk::LocalStructureImageFilter< EigenValueImageType, OutputImageType >;
 
   LocalStructureFilterType::Pointer localStructure = LocalStructureFilterType::New();
-  
+
   hessian->SetInput( reader->GetOutput() );
   eigen->SetInput( hessian->GetOutput() );
   localStructure->SetInput( eigen->GetOutput() );
@@ -87,7 +87,7 @@ int itkLocalStructureImageFilterTest1( int argc, char * argv [] )
   writer->SetFileName( argv[2] );
   writer->SetInput( localStructure->GetOutput() );
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkLungWallFeatureGeneratorTest1.cxx
+++ b/test/itkLungWallFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkLungWallFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = LungWallFeatureGeneratorType::SpatialObjectType;
 
   LungWallFeatureGeneratorType::Pointer  featureGenerator = LungWallFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -80,7 +80,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
     }
 
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -93,7 +93,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -105,7 +105,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -120,7 +120,7 @@ int itkLungWallFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   featureGenerator->SetLungThreshold( 100 );
   if( featureGenerator->GetLungThreshold() != 100 )
     {

--- a/test/itkMaximumFeatureAggregatorTest1.cxx
+++ b/test/itkMaximumFeatureAggregatorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkMaximumFeatureAggregatorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -44,7 +44,7 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -58,7 +58,7 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
   using AggregatorType = itk::MaximumFeatureAggregator< Dimension >;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -67,7 +67,7 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -93,17 +93,17 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
 
   featureAggregator->Update();
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   using OutputImageType = AggregatorType::OutputImageType;
@@ -117,7 +117,7 @@ int itkMaximumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkMaximumFeatureAggregatorTest2.cxx
+++ b/test/itkMaximumFeatureAggregatorTest2.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkMaximumFeatureAggregatorTest2.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -74,7 +74,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -88,7 +88,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
   using AggregatorType = itk::MaximumFeatureAggregatorDerived;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -97,7 +97,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -123,17 +123,17 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
 
   featureAggregator->Update();
 
    SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   using OutputImageType = AggregatorType::OutputImageType;
@@ -147,7 +147,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -180,7 +180,7 @@ int itkMaximumFeatureAggregatorTest2( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  try 
+  try
     {
     featureAggregator->GetInputFeature( 3 );
     std::cerr << "Failure to catch an exception for GetInputFeature() with out of range argument" << std::endl;

--- a/test/itkMinimumFeatureAggregatorTest1.cxx
+++ b/test/itkMinimumFeatureAggregatorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkMinimumFeatureAggregatorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -44,7 +44,7 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -58,7 +58,7 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
   using AggregatorType = itk::MinimumFeatureAggregator< Dimension >;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -67,10 +67,10 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator< Dimension >;
   CannyEdgesFeatureGeneratorType::Pointer  cannyEdgesGenerator = CannyEdgesFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -113,7 +113,7 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   using OutputImageType = AggregatorType::OutputImageType;
@@ -126,7 +126,7 @@ int itkMinimumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
   writer->UseCompressionOn();
 
-  try 
+  try
     {
     writer->Update();
     }

--- a/test/itkMinimumFeatureAggregatorTest2.cxx
+++ b/test/itkMinimumFeatureAggregatorTest2.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkMinimumFeatureAggregatorTest2.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -73,7 +73,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -87,7 +87,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
   using AggregatorType = itk::MinimumFeatureAggregatorDerived;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -96,7 +96,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -122,17 +122,17 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
 
   featureAggregator->Update();
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   using OutputImageType = AggregatorType::OutputImageType;
@@ -146,7 +146,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -179,7 +179,7 @@ int itkMinimumFeatureAggregatorTest2( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  try 
+  try
     {
     featureAggregator->GetInputFeature( 3 );
     std::cerr << "Failure to catch an exception for GetInputFeature() with out of range argument" << std::endl;

--- a/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkMorphologicalOpeningFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
   FeatureGeneratorType::Pointer  featureGenerator = FeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -80,7 +80,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
     }
 
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -93,7 +93,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -105,7 +105,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
   writer->SetInput( outputImage );
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -120,7 +120,7 @@ int itkMorphologicalOpeningFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   featureGenerator->SetLungThreshold( 100 );
   if( featureGenerator->GetLungThreshold() != 100 )
     {

--- a/test/itkMorphologicalOpenningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpenningFeatureGeneratorTest1.cxx
@@ -1,9 +1,9 @@
 /*=========================================================================
 
   Program:   Lesion Sizing Toolkit
-  Module:    itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
+  Module:    itkMorphologicalOpenningFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc.
+  Copyright (c) Kitware Inc. 
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -13,44 +13,42 @@
 
 =========================================================================*/
 
-// The output image here is going to be an image of covariant vectors.
-// (An advection field).
-//
-#include "itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h"
+#include "itkMorphologicalOpenningFeatureGenerator.h"
 #include "itkImage.h"
 #include "itkSpatialObject.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * argv [] )
+int itkMorphologicalOpenningFeatureGeneratorTest1( int argc, char * argv [] )
 {
 
   if( argc < 3 )
     {
     std::cerr << "Missing Arguments" << std::endl;
-    std::cerr << argv[0] << " inputImage outputImage [variance upperthreshold lowerthreshold]" << std::endl;
+    std::cerr << argv[0] << " inputImage outputImage [lungThreshold]" << std::endl;
     return EXIT_FAILURE;
     }
 
-  constexpr unsigned int Dimension = 3;
-  using InputPixelType = signed short;
-  using OutputPixelType = itk::CovariantVector< float >;
+  const unsigned int Dimension = 3;
 
-  using InputImageType = itk::Image< InputPixelType,  Dimension >;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  typedef signed short    InputPixelType;
+  typedef float           OutputPixelType;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  typedef itk::Image< InputPixelType,  Dimension >   InputImageType;
+  typedef itk::Image< OutputPixelType, Dimension >   OutputImageType;
 
-  using InputImageSpatialObjectType = itk::ImageSpatialObject< Dimension, InputPixelType  >;
-  using OutputImageSpatialObjectType = itk::ImageSpatialObject< Dimension, OutputPixelType >;
+  typedef itk::ImageFileReader< InputImageType >     ReaderType;
+  typedef itk::ImageFileWriter< OutputImageType >    WriterType;
+
+  typedef itk::ImageSpatialObject< Dimension, InputPixelType  > InputImageSpatialObjectType;
+  typedef itk::ImageSpatialObject< Dimension, OutputPixelType > OutputImageSpatialObjectType;
 
   ReaderType::Pointer reader = ReaderType::New();
 
   reader->SetFileName( argv[1] );
 
-  try
+  try 
     {
     reader->Update();
     }
@@ -60,11 +58,11 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
     return EXIT_FAILURE;
     }
 
-  using CannyEdgesDistanceAdvectionFieldFeatureGeneratorType = itk::CannyEdgesDistanceAdvectionFieldFeatureGenerator< Dimension >;
-  using SpatialObjectType = CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::SpatialObjectType;
+  typedef itk::MorphologicalOpenningFeatureGenerator< Dimension >   FeatureGeneratorType;
+  typedef FeatureGeneratorType::SpatialObjectType    SpatialObjectType;
 
-  CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::Pointer  featureGenerator = CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::New();
-
+  FeatureGeneratorType::Pointer  featureGenerator = FeatureGeneratorType::New();
+  
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -78,20 +76,11 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
 
   if( argc > 3 )
     {
-    featureGenerator->SetSigma( atof( argv[3] ) );
+    featureGenerator->SetLungThreshold( atoi( argv[3] ) );
     }
 
-  if( argc > 4 )
-    {
-    featureGenerator->SetUpperThreshold( atof( argv[4] ) );
-    }
 
-  if( argc > 5 )
-    {
-    featureGenerator->SetLowerThreshold( atof( argv[4] ) );
-    }
-
-  try
+  try 
     {
     featureGenerator->Update();
     }
@@ -104,7 +93,7 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject =
+  OutputImageSpatialObjectType::ConstPointer outputObject = 
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -112,11 +101,11 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
   WriterType::Pointer writer = WriterType::New();
 
   writer->SetFileName( argv[2] );
-  writer->SetInput( outputImage );
   writer->UseCompressionOn();
+  writer->SetInput( outputImage );
 
 
-  try
+  try 
     {
     writer->Update();
     }
@@ -131,6 +120,20 @@ int itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1( int argc, char * a
 
   featureGenerator->Print( std::cout );
 
+ 
+  featureGenerator->SetLungThreshold( 100 );
+  if( featureGenerator->GetLungThreshold() != 100 )
+    {
+    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  featureGenerator->SetLungThreshold( 200 );
+  if( featureGenerator->GetLungThreshold() != 200 )
+    {
+    std::cerr << "Error in Set/GetLungThreshold()" << std::endl;
+    return EXIT_FAILURE;
+    }
 
   return EXIT_SUCCESS;
 }

--- a/test/itkRegionGrowingSegmentationModuleTest1.cxx
+++ b/test/itkRegionGrowingSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkRegionGrowingSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -27,7 +27,7 @@ int itkRegionGrowingSegmentationModuleTest1( int itkNotUsed(argc), char * itkNot
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
   ImageSpatialObjectType::Pointer inputObject = ImageSpatialObjectType::New();
@@ -46,6 +46,6 @@ int itkRegionGrowingSegmentationModuleTest1( int itkNotUsed(argc), char * itkNot
   segmentationModule->Print( std::cout );
 
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -38,7 +38,7 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   using SegmentationModuleType = itk::ShapeDetectionLevelSetSegmentationModule< Dimension >;
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using InputImageType = SegmentationModuleType::InputImageType;
   using FeatureImageType = SegmentationModuleType::FeatureImageType;
   using OutputImageType = SegmentationModuleType::OutputImageType;
@@ -70,7 +70,7 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 
   featureReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     rescaler->Update();
     featureReader->Update();
@@ -101,17 +101,17 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
 
   if( argc > 4 )
     {
-    propagationScaling = atof( argv[4] ); 
+    propagationScaling = atof( argv[4] );
     }
 
   if( argc > 5 )
     {
-    curvatureScaling = atof( argv[5] ); 
+    curvatureScaling = atof( argv[5] );
     }
 
   if( argc > 6 )
     {
-    maximumNumberOfIterations = atoi( argv[6] ); 
+    maximumNumberOfIterations = atoi( argv[6] );
     }
 
 
@@ -124,7 +124,7 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
 
-  OutputSpatialObjectType::ConstPointer outputObject = 
+  OutputSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputSpatialObjectType * >( segmentation.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -134,7 +134,7 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   writer->SetFileName( argv[3] );
   writer->SetInput( outputImage );
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -148,6 +148,6 @@ int itkShapeDetectionLevelSetSegmentationModuleTest1( int argc, char * argv [] )
   segmentationModule->Print( std::cout );
 
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkSigmoidFeatureGeneratorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkSigmoidFeatureGeneratorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -48,7 +48,7 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   reader->SetFileName( argv[1] );
 
-  try 
+  try
     {
     reader->Update();
     }
@@ -62,7 +62,7 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
   using SpatialObjectType = SigmoidFeatureGeneratorType::SpatialObjectType;
 
   SigmoidFeatureGeneratorType::Pointer  featureGenerator = SigmoidFeatureGeneratorType::New();
-  
+
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -104,7 +104,7 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  try 
+  try
     {
     featureGenerator->Update();
     }
@@ -117,7 +117,7 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( feature.GetPointer() );
 
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
@@ -129,7 +129,7 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -144,6 +144,6 @@ int itkSigmoidFeatureGeneratorTest1( int argc, char * argv [] )
 
   featureGenerator->Print( std::cout );
 
- 
+
   return EXIT_SUCCESS;
 }

--- a/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -27,7 +27,7 @@ int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
   SegmentationModuleType::Pointer  segmentationModule = SegmentationModuleType::New();
-  
+
   using ImageSpatialObjectType = itk::ImageSpatialObject< Dimension >;
 
   ImageSpatialObjectType::Pointer inputObject = ImageSpatialObjectType::New();
@@ -95,6 +95,6 @@ int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * 
   segmentationModule->Print( std::cout );
 
   std::cout << "Class name = " << segmentationModule->GetNameOfClass() << std::endl;
-  
+
   return EXIT_SUCCESS;
 }

--- a/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
+++ b/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -52,7 +52,7 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
   reader->SetFileName( argv[1] );
   writer->SetFileName( argv[2] );
 
-  using ThresholderType = itk::BinaryThresholdImageFilter< 
+  using ThresholderType = itk::BinaryThresholdImageFilter<
     InputImageType, OutputImageType >;
 
   ThresholderType::Pointer thresholder = ThresholderType::New();
@@ -62,8 +62,8 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
 
   thresholder->SetOutsideValue(  0 );
   thresholder->SetInsideValue( 255 );
- 
-  using FilterType = itk::VotingBinaryHoleFillFloodingImageFilter< 
+
+  using FilterType = itk::VotingBinaryHoleFillFloodingImageFilter<
     OutputImageType, OutputImageType >;
 
   FilterType::Pointer filter = FilterType::New();
@@ -71,7 +71,7 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
   const unsigned int radius = atoi( argv[4] );
 
   OutputImageType::SizeType indexRadius;
-  
+
   indexRadius[0] = radius; // radius along x
   indexRadius[1] = radius; // radius along y
   indexRadius[2] = radius; // radius along z
@@ -101,7 +101,7 @@ int itkVotingBinaryHoleFillFloodingImageFilterTest1( int argc, char * argv[] )
   writer->Update();
 
   std::cout << "Class name " << filter->GetNameOfClass() << std::endl;
-  
+
   filter->Print( std::cout );
 
   std::cout << "Iteration used = " << filter->GetCurrentIterationNumber()     << std::endl;

--- a/test/itkWeightedSumFeatureAggregatorTest1.cxx
+++ b/test/itkWeightedSumFeatureAggregatorTest1.cxx
@@ -3,7 +3,7 @@
   Program:   Lesion Sizing Toolkit
   Module:    itkWeightedSumFeatureAggregatorTest1.cxx
 
-  Copyright (c) Kitware Inc. 
+  Copyright (c) Kitware Inc.
   All rights reserved.
   See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
 
@@ -45,7 +45,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
 
   inputImageReader->SetFileName( argv[2] );
 
-  try 
+  try
     {
     inputImageReader->Update();
     }
@@ -59,7 +59,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   using AggregatorType = itk::WeightedSumFeatureAggregator< Dimension >;
 
   AggregatorType::Pointer  featureAggregator = AggregatorType::New();
-  
+
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator< Dimension >;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
@@ -68,7 +68,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator< Dimension >;
   SigmoidFeatureGeneratorType::Pointer  sigmoidGenerator = SigmoidFeatureGeneratorType::New();
- 
+
   featureAggregator->AddFeatureGenerator( lungWallGenerator );
   featureAggregator->AddFeatureGenerator( vesselnessGenerator );
   featureAggregator->AddFeatureGenerator( sigmoidGenerator );
@@ -100,22 +100,22 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   vesselnessGenerator->SetSigma( 1.0 );
   vesselnessGenerator->SetAlpha1( 0.5 );
   vesselnessGenerator->SetAlpha2( 2.0 );
- 
+
   sigmoidGenerator->SetAlpha(  1.0  );
   sigmoidGenerator->SetBeta( -200.0 );
- 
+
   featureAggregator->Update();
 
    SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
   using OutputImageSpatialObjectType = AggregatorType::OutputImageSpatialObjectType;
-  OutputImageSpatialObjectType::ConstPointer outputObject = 
+  OutputImageSpatialObjectType::ConstPointer outputObject =
     dynamic_cast< const OutputImageSpatialObjectType * >( finalFeature.GetPointer() );
 
   using OutputImageType = AggregatorType::OutputImageType;
   OutputImageType::ConstPointer outputImage = outputObject->GetImage();
 
- 
+
   using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
   OutputWriterType::Pointer writer = OutputWriterType::New();
 
@@ -124,7 +124,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   writer->UseCompressionOn();
 
 
-  try 
+  try
     {
     writer->Update();
     }
@@ -141,7 +141,7 @@ int itkWeightedSumFeatureAggregatorTest1( int argc, char * argv [] )
   //
   featureAggregator->AddWeight( 13.0 );
 
-  try 
+  try
     {
     featureAggregator->Update();
     std::cerr << "Failure to produce expected exception" << std::endl;


### PR DESCRIPTION
The vcl_ functions are aliases to the C++11 variants,
so just use C++11 directly.