### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/Utilities/Visualization/IsoSurfaceVolumeEstimation.cxx
+++ b/Utilities/Visualization/IsoSurfaceVolumeEstimation.cxx
@@ -25,7 +25,7 @@
 #include "vtkMassProperties.h"
 #include "vtkCleanPolyData.h"
 #include "vtkTriangleFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "vtkVersion.h"
 
 
@@ -81,8 +81,8 @@ int main(int argc, char * argv [] )
   //
   // Compute the radius of the equivalent-volume sphere
   //
-  const double radius3 = ( ( volume * 3.0 ) / ( 4.0 * vnl_math::pi ) );
-  const double radius = vnl_math::cuberoot( radius3 );
+  const double radius3 = ( ( volume * 3.0 ) / ( 4.0 * itk::Math::pi ) );
+  const double radius = std::cbrt( radius3 );
 
 
   const std::string segmentationMethodID = argv[3];

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -18,7 +18,7 @@
 #define itkDescoteauxSheetnessImageFilter_h
 
 #include "itkUnaryFunctorImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -67,9 +67,9 @@ public:
     auto a2 = static_cast<double>( A[1] );
     auto a3 = static_cast<double>( A[2] );
 
-    double l1 = vnl_math::abs( a1 );
-    double l2 = vnl_math::abs( a2 );
-    double l3 = vnl_math::abs( a3 );
+    double l1 = itk::Math::abs( a1 );
+    double l2 = itk::Math::abs( a2 );
+    double l3 = itk::Math::abs( a3 );
 
     //
     // Sort the values by their absolute value.
@@ -126,13 +126,13 @@ public:
     //
     // Avoid divisions by zero (or close to zero)
     //
-    if( static_cast<double>( l3 ) < vnl_math::eps )
+    if( static_cast<double>( l3 ) < itk::Math::eps )
       {
       return static_cast<TOutput>( sheetness );
       }
 
     const double Rs = l2 / l3;
-    const double Rb = vnl_math::abs( l3 + l3 - l2 - l1 ) / l3;
+    const double Rb = itk::Math::abs( l3 + l3 - l2 - l1 ) / l3;
     const double Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
     sheetness  =         std::exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) );

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -18,7 +18,7 @@
 #define itkFrangiTubularnessImageFilter_h
 
 #include "itkUnaryFunctorImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -77,9 +77,9 @@ public:
     auto a2 = static_cast<double>( A[1] );
     auto a3 = static_cast<double>( A[2] );
 
-    double l1 = vnl_math::abs( a1 );
-    double l2 = vnl_math::abs( a2 );
-    double l3 = vnl_math::abs( a3 );
+    double l1 = itk::Math::abs( a1 );
+    double l2 = itk::Math::abs( a2 );
+    double l3 = itk::Math::abs( a3 );
 
     //
     // Sort the values by their absolute value.
@@ -136,7 +136,7 @@ public:
       }
 
     // avoid divisions by zero
-    if( l2 < vnl_math::eps || l3 < vnl_math::eps )
+    if( l2 < itk::Math::eps || l3 < itk::Math::eps )
       {
       return tubularness;
       }

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -18,7 +18,7 @@
 #define itkLocalStructureImageFilter_h
 
 #include "itkUnaryFunctorImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -70,9 +70,9 @@ public:
     auto a2 = static_cast<double>( A[1] );
     auto a3 = static_cast<double>( A[2] );
 
-    double l1 = vnl_math::abs( a1 );
-    double l2 = vnl_math::abs( a2 );
-    double l3 = vnl_math::abs( a3 );
+    double l1 = itk::Math::abs( a1 );
+    double l2 = itk::Math::abs( a2 );
+    double l3 = itk::Math::abs( a3 );
 
     //
     // Sort the values by their absolute value.
@@ -110,12 +110,12 @@ public:
     //
     // Avoid divisions by zero.
     //
-    if( l3 < vnl_math::eps )
+    if( l3 < itk::Math::eps )
       {
       return 0.0;
       }
 
-    const double L3 = vnl_math::abs( static_cast<double>( a3 ) );
+    const double L3 = itk::Math::abs( static_cast<double>( a3 ) );
     const double W = WeightFunctionOmega( a2, a3 );
     const double F = WeightFunctionOmega( a1, a3 );
 
@@ -127,12 +127,12 @@ public:
     {
     if( ls <= 0.0 && lt <= ls )
       {
-      return ( 1 + std::pow( ls / vnl_math::abs( lt ), m_Gamma ) );
+      return ( 1 + std::pow( ls / itk::Math::abs( lt ), m_Gamma ) );
       }
-    const double abslt = vnl_math::abs( lt );
+    const double abslt = itk::Math::abs( lt );
     if( ls > 0.0  &&  abslt / m_Gamma > ls )
       {
-      return std::pow( 1 - m_Alpha * ls / vnl_math::abs( lt ), m_Gamma );
+      return std::pow( 1 - m_Alpha * ls / itk::Math::abs( lt ), m_Gamma );
       }
     return 0.0;
     }

--- a/test/itkDescoteauxSheetnessImageFilterTest2.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest2.cxx
@@ -200,7 +200,7 @@ int itkDescoteauxSheetnessImageFilterTest2( int argc, char * argv [] )
   while( !citr.IsAtEnd() )
     {
 
-    bool closeToSheet = ( vnl_math::abs( iitr.GetIndex()[2] - planeIndex[2] ) < 2 );
+    bool closeToSheet = ( itk::Math::abs( iitr.GetIndex()[2] - planeIndex[2] ) < 2 );
 
     if( iitr.Get() > meanValue || closeToSheet )
       {

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
@@ -141,7 +141,7 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest1( int itkNotUsed(argc), cha
 
   const double difference = volume1 - expectedVolume;
 
-  const double percentage = 100.0 * vnl_math::abs( difference ) / expectedVolume;
+  const double percentage = 100.0 * itk::Math::abs( difference ) / expectedVolume;
 
   const double epsilon = 1e-6;
   const double allowedVolumePercentageError = 1e-1; // 0.1%

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
@@ -64,8 +64,8 @@ int itkGrayscaleImageSegmentationVolumeEstimatorTest2( int argc, char * argv [] 
   //
   // Compute the radius of the equivalent-volume sphere
   //
-  const double radius3 = ( ( volume * 3.0 ) / ( 4.0 * vnl_math::pi ) );
-  const double radius = vnl_math::cuberoot( radius3 );
+  const double radius3 = ( ( volume * 3.0 ) / ( 4.0 * itk::Math::pi ) );
+  const double radius = std::cbrt( radius3 );
 
 
   const std::string segmentationMethodID = argv[2];


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace