### PR TITLE
COMP: Fix `SpatialObject` module refactoring-derived errors

### DIFF
--- a/Examples/LesionSegmentationCLI.h
+++ b/Examples/LesionSegmentationCLI.h
@@ -32,7 +32,7 @@ public:
   using RealImageType = itk::Image< float, ImageDimension >;
 
   using SeedSpatialObjectType = itk::LandmarkSpatialObject< 3 >;
-  using PointListType = SeedSpatialObjectType::PointListType;
+  using LandmarkPointListType = SeedSpatialObjectType::LandmarkPointListType;
 
   LesionSegmentationCLI( int argc, char *argv[] ) : MetaCommand()
   {
@@ -88,7 +88,7 @@ public:
       }
     else
       {
-      PointListType seeds = this->GetSeeds();
+      LandmarkPointListType seeds = this->GetSeeds();
       seeds[0];
       for (int i = 0; i < 3; i++)
         {
@@ -111,12 +111,12 @@ public:
     return s;
     }
 
-  PointListType GetSeeds()
+  LandmarkPointListType GetSeeds()
     {
     std::list< std::string > seedsString = this->GetValueAsList("Seeds");
     std::list< std::string >::const_iterator fit = seedsString.begin();
     const unsigned int nb_of_markers = seedsString.size() / 3;
-    PointListType seeds(nb_of_markers);
+    LandmarkPointListType seeds(nb_of_markers);
     for (unsigned int i = 0; i < nb_of_markers; i++)
       {
       double sx = (double)atof((*fit).c_str());

--- a/Utilities/Visualization/ViewImageSlicesAndSegmentationContours.cxx
+++ b/Utilities/Visualization/ViewImageSlicesAndSegmentationContours.cxx
@@ -80,28 +80,28 @@ int main(int argc, char * argv [] )
     landmarkPointsReader->SetFileName( argv[2] );
     landmarkPointsReader->Update();
 
-    SpatialObjectReaderType::ScenePointer scene = landmarkPointsReader->GetScene();
+    SpatialObjectReaderType::GroupPointer group = landmarkPointsReader->GetGroup();
 
-    if( !scene )
+    if( !group )
       {
-      std::cerr << "No Scene : [FAILED]" << std::endl;
+      std::cerr << "No Group : [FAILED]" << std::endl;
       return EXIT_FAILURE;
       }
 
-    std::cout << "Number of object in the scene:" << scene->GetNumberOfObjects(1) << std::endl;
+    std::cout << "Number of objects in the group:" << group->GetNumberOfObjects(1) << std::endl;
 
-    using ObjectListType = SpatialObjectReaderType::SceneType::ObjectListType;
+    using ObjectListType = SpatialObjectReaderType::GroupType::ObjectListType;
 
-    ObjectListType * sceneChildren = scene->GetObjects(999999);
+    ObjectListType * groupChildren = group->GetObjects(999999);
 
-    ObjectListType::const_iterator spatialObjectItr = sceneChildren->begin();
+    ObjectListType::const_iterator spatialObjectItr = groupChildren->begin();
 
     /** Type of the input set of seed points. They are stored in a Landmark Spatial Object. */
     using InputSpatialObjectType = itk::LandmarkSpatialObject< 3 >;
 
     const InputSpatialObjectType * landmarkSpatialObject = NULL;
 
-    while( spatialObjectItr != sceneChildren->end() )
+    while( spatialObjectItr != groupChildren->end() )
       {
       std::string objectName = (*spatialObjectItr)->GetTypeName();
       if( objectName == "LandmarkSpatialObject" )
@@ -112,12 +112,12 @@ int main(int argc, char * argv [] )
       spatialObjectItr++;
       }
 
-    using PointListType = InputSpatialObjectType::PointListType;
+    using LandmarkPointListType = InputSpatialObjectType::LandmarkPointListType;
     using SpatialObjectPointType = InputSpatialObjectType::SpatialObjectPointType;
     using PointType = SpatialObjectPointType::PointType;
 
 
-    const PointListType & points = landmarkSpatialObject->GetPoints();
+    const LandmarkPointListType & points = landmarkSpatialObject->GetPoints();
 
     // Grab the first point in the list of seed points
     PointType point = points[0].GetPosition();

--- a/include/itkConfidenceConnectedSegmentationModule.hxx
+++ b/include/itkConfidenceConnectedSegmentationModule.hxx
@@ -78,16 +78,16 @@ ConfidenceConnectedSegmentationModule<NDimension>
 
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
-  using PointListType = typename InputSpatialObjectType::PointListType;
+  using LandmarkPointListType = typename InputSpatialObjectType::LandmarkPointListType;
   using IndexType = typename FeatureImageType::IndexType;
 
-  const PointListType & points = inputSeeds->GetPoints();
+  const LandmarkPointListType & points = inputSeeds->GetPoints();
 
   IndexType index;
 
   for( unsigned int i=0; i < numberOfPoints; i++ )
     {
-    featureImage->TransformPhysicalPointToIndex( points[i].GetPosition(), index );
+    featureImage->TransformPhysicalPointToIndex( points[i].GetPositionInObjectSpace(), index );
     filter->AddSeed( index );
     }
 

--- a/include/itkConnectedThresholdSegmentationModule.hxx
+++ b/include/itkConnectedThresholdSegmentationModule.hxx
@@ -78,16 +78,16 @@ ConnectedThresholdSegmentationModule<NDimension>
 
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
-  using PointListType = typename InputSpatialObjectType::PointListType;
+  using LandmarkPointListType = typename InputSpatialObjectType::LandmarkPointListType;
   using IndexType = typename FeatureImageType::IndexType;
 
-  const PointListType & points = inputSeeds->GetPoints();
+  const LandmarkPointListType & points = inputSeeds->GetPoints();
 
   IndexType index;
 
   for( unsigned int i=0; i < numberOfPoints; i++ )
     {
-    featureImage->TransformPhysicalPointToIndex( points[i].GetPosition(), index );
+    featureImage->TransformPhysicalPointToIndex( points[i].GetPositionInObjectSpace(), index );
     filter->AddSeed( index );
     }
 

--- a/include/itkFastMarchingSegmentationModule.hxx
+++ b/include/itkFastMarchingSegmentationModule.hxx
@@ -97,7 +97,7 @@ FastMarchingSegmentationModule<NDimension>
   const InputSpatialObjectType * inputSeeds = this->GetInternalInputLandmarks();
   const unsigned int numberOfPoints = inputSeeds->GetNumberOfPoints();
 
-  using PointListType = typename InputSpatialObjectType::PointListType;
+  using LandmarkPointListType = typename InputSpatialObjectType::LandmarkPointListType;
   using IndexType = typename FeatureImageType::IndexType;
   using IndexType = typename FeatureImageType::IndexType;
   using NodeContainer = typename FilterType::NodeContainer;
@@ -105,13 +105,13 @@ FastMarchingSegmentationModule<NDimension>
 
   typename NodeContainer::Pointer trialPoints = NodeContainer::New();
 
-  const PointListType & points = inputSeeds->GetPoints();
+  const LandmarkPointListType & points = inputSeeds->GetPoints();
 
   IndexType index;
 
   for( unsigned int i=0; i < numberOfPoints; i++ )
     {
-    featureImage->TransformPhysicalPointToIndex( points[i].GetPosition(), index );
+    featureImage->TransformPhysicalPointToIndex( points[i].GetPositionInObjectSpace(), index );
 
     NodeType node;
 

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -78,7 +78,7 @@ public:
   void AddFeatureGenerator( FeatureGeneratorType * generator );
 
   /** Check all feature generators and return consolidate MTime */
-  unsigned long GetMTime() const override;
+  ModifiedTimeType GetMTime() const override;
 
 protected:
   FeatureAggregator();

--- a/include/itkFeatureAggregator.hxx
+++ b/include/itkFeatureAggregator.hxx
@@ -125,17 +125,17 @@ FeatureAggregator<NDimension>
 }
 
 template <unsigned int NDimension>
-unsigned long
+ModifiedTimeType
 FeatureAggregator<NDimension>
 ::GetMTime() const
 {
   // MTime is the max of mtime of all feature generators.
-  unsigned long mtime = this->Superclass::GetMTime();
+  ModifiedTimeType  mtime = this->Superclass::GetMTime();
   auto gitr = this->m_FeatureGenerators.begin();
   auto gend = this->m_FeatureGenerators.end();
   while( gitr != gend )
     {
-    const unsigned long t = (*gitr)->GetMTime();
+    const ModifiedTimeType  t = (*gitr)->GetMTime();
     if (t > mtime)
       {
       mtime = t;

--- a/include/itkLandmarksReader.h
+++ b/include/itkLandmarksReader.h
@@ -77,8 +77,8 @@ protected:
 private:
   using SpatialObjectReaderType = SpatialObjectReader< NDimension, unsigned short >;
   using SpatialObjectReaderPointer = typename SpatialObjectReaderType::Pointer;
-  using SceneType = typename SpatialObjectReaderType::SceneType;
-  using ObjectListType = typename SceneType::ObjectListType;
+  using GroupType = typename SpatialObjectReaderType::GroupType;
+  using ObjectListType = typename GroupType::ObjectListType;
 
   std::string                     m_FileName;
   SpatialObjectReaderPointer      m_SpatialObjectReader;

--- a/include/itkLandmarksReader.hxx
+++ b/include/itkLandmarksReader.hxx
@@ -67,20 +67,20 @@ LandmarksReader<NDimension>
 
   this->m_SpatialObjectReader->Update();
 
-  typename SpatialObjectReaderType::ScenePointer scene = this->m_SpatialObjectReader->GetScene();
+  typename SpatialObjectReaderType::GroupPointer group = this->m_SpatialObjectReader->GetGroup();
 
-  if( !scene )
+  if( !group )
     {
-    itkExceptionMacro("Couldn't fine a scene in file" << this->GetFileName() );
+    itkExceptionMacro("Couldn't fine a group in file" << this->GetFileName() );
     }
 
-  ObjectListType * sceneChildren = scene->GetObjects(999999);
+  ObjectListType * groupChildren = group->GetChildren(999999);
 
-  typename ObjectListType::const_iterator spatialObjectItr = sceneChildren->begin();
+  typename ObjectListType::const_iterator spatialObjectItr = groupChildren->begin();
 
   typename SpatialObjectType::Pointer landmarkSpatialObject;
 
-  while( spatialObjectItr != sceneChildren->end() )
+  while( spatialObjectItr != groupChildren->end() )
     {
     std::string objectName = (*spatialObjectItr)->GetTypeName();
     if( objectName == "LandmarkSpatialObject" )
@@ -105,7 +105,7 @@ LandmarksReader<NDimension>
 
   outputObject->SetPoints( landmarkSpatialObject->GetPoints() );
 
-  delete sceneChildren;
+  delete groupChildren;
 }
 
 /*

--- a/include/itkLesionSegmentationImageFilter8.h
+++ b/include/itkLesionSegmentationImageFilter8.h
@@ -127,10 +127,10 @@ public:
   itkBooleanMacro( UseVesselEnhancingDiffusion );
 
   using SeedSpatialObjectType = itk::LandmarkSpatialObject< ImageDimension >;
-  using PointListType = typename SeedSpatialObjectType::PointListType;
+  using LandmarkPointListType = typename SeedSpatialObjectType::LandmarkPointListType;
 
-  void SetSeeds( PointListType p ) { this->m_Seeds = p; }
-  PointListType GetSeeds() { return m_Seeds; }
+  void SetSeeds( LandmarkPointListType p ) { this->m_Seeds = p; }
+  LandmarkPointListType GetSeeds() { return m_Seeds; }
 
   /** Report progress */
   void ProgressUpdate( Object * caller, const EventObject & event );
@@ -192,7 +192,7 @@ private:
   typename CommandType::Pointer                       m_CommandObserver;
   RegionType                                          m_RegionOfInterest;
   std::string                                         m_StatusMessage;
-  typename SeedSpatialObjectType::PointListType       m_Seeds;
+  typename SeedSpatialObjectType::LandmarkPointListType m_Seeds;
   typename InputImageSpatialObjectType::Pointer       m_InputSpatialObject;
   bool                                                m_ResampleThickSliceData;
   double                                              m_AnisotropyThreshold;

--- a/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
+++ b/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
@@ -79,11 +79,11 @@ int main( int argc, char ** argv )
     return EXIT_FAILURE;
     }
 
-  using PointListType = InputSpatialObjectType::PointListType;
+  using LandmarkPointListType = InputSpatialObjectType::LandmarkPointListType;
 
-  const PointListType & points = inputSeeds->GetPoints();
+  const LandmarkPointListType & points = inputSeeds->GetPoints();
 
-  InputImageType::PointType seedPoint = points[0].GetPosition();
+  InputImageType::PointType seedPoint = points[0].GetPositionInObjectSpace();
 
   FilterType::Pointer filter = FilterType::New();
 

--- a/test/LandmarkSpatialObjectWriterTest.cxx
+++ b/test/LandmarkSpatialObjectWriterTest.cxx
@@ -33,30 +33,30 @@ int LandmarkSpatialObjectWriterTest( int itkNotUsed(argc), char * argv [] )
   using LandmarkType = itk::LandmarkSpatialObject< Dimension >;
   using LandmarkPointer = LandmarkType::Pointer;
   using SpatialPointType = LandmarkType::SpatialObjectPointType;
-  using PointListType = LandmarkType::PointListType;
+  using LandmarkPointListType = LandmarkType::LandmarkPointListType;
 
-  PointListType listOfPoints;
+  LandmarkPointListType listOfPoints;
 
   SpatialPointType p;
 
   p.SetColor(1,0,0,1);
 
-  p.SetPosition( 0.4, 0.5, 0.7 );
+  p.SetPositionInObjectSpace( 0.4, 0.5, 0.7 );
   listOfPoints.push_back( p );
 
-  p.SetPosition( 0.5, 0.4, 0.7 );
+  p.SetPositionInObjectSpace( 0.5, 0.4, 0.7 );
   listOfPoints.push_back( p );
 
-  p.SetPosition( 0.6, 0.3, 0.7 );
+  p.SetPositionInObjectSpace( 0.6, 0.3, 0.7 );
   listOfPoints.push_back( p );
 
-  p.SetPosition( 0.7, 0.2, 0.7 );
+  p.SetPositionInObjectSpace( 0.7, 0.2, 0.7 );
   listOfPoints.push_back( p );
 
 
   LandmarkPointer landmarkSpatialObject = LandmarkType::New();
   landmarkSpatialObject->SetPoints( listOfPoints );
-  landmarkSpatialObject->GetProperty()->SetName("Landmark 1");
+  landmarkSpatialObject->GetProperty().SetName("Landmark 1");
 
   WriterType::Pointer writer = WriterType::New();
 

--- a/test/itkLandmarksReaderTest1.cxx
+++ b/test/itkLandmarksReaderTest1.cxx
@@ -72,27 +72,27 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
   landmarkPointsReader->SetFileName( argv[1] );
   landmarkPointsReader->Update();
 
-  SpatialObjectReaderType::ScenePointer scene = landmarkPointsReader->GetScene();
+  SpatialObjectReaderType::GroupPointer group = landmarkPointsReader->GetGroup();
 
-  if( !scene )
+  if( !group )
     {
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "No Scene." << std::endl;
+    std::cerr << "No Group." << std::endl;
     return EXIT_FAILURE;
     }
 
-  std::cout << "Number of object in the scene:" << scene->GetNumberOfObjects(1) << std::endl;
+  std::cout << "Number of children in the group:" << group->GetNumberOfChildren(1) << std::endl;
 
-  using ObjectListType = SpatialObjectReaderType::SceneType::ObjectListType;
+  using ObjectListType = SpatialObjectReaderType::GroupType::ObjectListType;
 
-  ObjectListType * sceneChildren = scene->GetObjects(999999);
+  ObjectListType * groupChildren = group->GetChildren(999999);
 
-  ObjectListType::const_iterator spatialObjectItr = sceneChildren->begin();
+  ObjectListType::const_iterator spatialObjectItr = groupChildren->begin();
 
 
   const InputSpatialObjectType * landmarkSpatialObject2 = nullptr;
 
-  while( spatialObjectItr != sceneChildren->end() )
+  while( spatialObjectItr != groupChildren->end() )
     {
     std::string objectName = (*spatialObjectItr)->GetTypeName();
     if( objectName == "LandmarkSpatialObject" )
@@ -103,7 +103,7 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
     spatialObjectItr++;
     }
 
-  using PointListType = InputSpatialObjectType::PointListType;
+  using LandmarkPointListType = InputSpatialObjectType::LandmarkPointListType;
 
   const unsigned int numberOfPoints1 = landmarkSpatialObject1->GetNumberOfPoints();
   const unsigned int numberOfPoints2 = landmarkSpatialObject2->GetNumberOfPoints();
@@ -118,17 +118,17 @@ int itkLandmarksReaderTest1( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-  const PointListType & points1 = landmarkSpatialObject1->GetPoints();
-  const PointListType & points2 = landmarkSpatialObject2->GetPoints();
+  const LandmarkPointListType & points1 = landmarkSpatialObject1->GetPoints();
+  const LandmarkPointListType & points2 = landmarkSpatialObject2->GetPoints();
 
   for( unsigned int i = 0; i < numberOfPoints1; ++i )
     {
-    if( points1[i].GetPosition() != points2[i].GetPosition() )
+    if( points1[i].GetPositionInObjectSpace() != points2[i].GetPositionInObjectSpace() )
       {
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Error : point " << i << " has different positions" << std::endl;
-      std::cerr << "Expected value " << points2[i].GetPosition() << std::endl;
-      std::cerr << " differs from" << points1[i].GetPosition() << std::endl;
+      std::cerr << "Expected value " << points2[i].GetPositionInObjectSpace() << std::endl;
+      std::cerr << " differs from" << points1[i].GetPositionInObjectSpace() << std::endl;
       return EXIT_FAILURE;
       }
     }


### PR DESCRIPTION
Fix `SpatialObject` module refactoring-derived errors.

Fixes:
```
/Users/Kitware/Dashboards/TestsModules/Remote/LesionSizingToolkit/include/itkLandmarksReader.h:80:55:
error: no type named 'SceneType' in 'itk::SpatialObjectReader<3, unsigned
short, itk::DefaultStaticMeshTraits<unsigned short, 3, 3, float, float,
unsigned short> >'
  using SceneType = typename SpatialObjectReaderType::SceneType;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```

and
```
/Users/Kitware/Dashboards/TestsModules/Remote/LesionSizingToolkit/include/itkConnectedThresholdSegmentationModule.hxx:81:58:
error: no type named 'PointListType' in 'itk::LandmarkSpatialObject<3>'
  using PointListType = typename InputSpatialObjectType::PointListType;
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```

raised at:
http://testing.cdash.org/viewBuildError.php?buildid=5854571

and stemming from the changes introduced in:
https://github.com/InsightSoftwareConsortium/ITK/pull/613/commits/a1a98aa1f361b7a5ea3d431f9f28a1263dedca2d

and
https://github.com/InsightSoftwareConsortium/ITK/commit/747bb86eeb64bc08ffcaa9b0beb357bf87e01a9b

And other errors stemming from
https://github.com/InsightSoftwareConsortium/ITK/pull/613