### PR TITLE
COMP: Fix VTK configuration errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,65 @@ endif()
 
 option(LSTK_USE_VTK "Build visualization helper tools." OFF)
 if(LSTK_USE_VTK)
-  find_package(VTK REQUIRED COMPONENTS vtkRenderingVolume vtkIOGeometry vtkIOLegacy vtkIOImage vtkInteractionWidgets vtkInteractionImage)
-  set(VERSION_MIN "6.0.0")
-  if(${VTK_VERSION} VERSION_LESS ${VERSION_MIN})
-    message(ERROR " LSTK_USE_VTK requires VTK version ${VERSION_MIN} or newer but the current version is ${VTK_VERSION}")
-  endif()
-  include(${VTK_USE_FILE})
+  if(NOT COMMAND vtk_module_config)
+    macro(vtk_module_config ns)
+       foreach(arg ${ARGN})
+        if(${arg} MATCHES "^[Vv][Tt][Kk]")
+          string(REGEX REPLACE "^[Vv][Tt][Kk]" "" _arg ${arg})
+        else()
+          set(_arg ${arg})
+        endif()
+        set(${ns}_LIBRARIES ${${ns}_LIBRARIES} VTK::${_arg})
+       endforeach()
+    endmacro()
 
-  set(ITK_VTK_LSTK_LIBRARIES ${LesionSizingToolkit_LIBRARIES} ${VTK_LIBRARIES})
+    if(NOT VTK_RENDERING_BACKEND)
+      set(VTK_RENDERING_BACKEND OpenGL2)
+    endif()
+  endif()
+
+  if(NOT VTK_RENDERING_BACKEND)
+    if(NOT COMMAND vtk_module_config)
+      set(VTK_RENDERING_BACKEND OpenGL2)
+    else()
+      set(VTK_RENDERING_BACKEND OpenGL)
+    endif()
+  endif()
+
+  set(_target_freetypeopengl)
+  if(TARGET ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+    set(_target_freetypeopengl ${_target_prefix}RenderingFreeType${VTK_RENDERING_BACKEND})
+  endif()
+
+  set(_required_vtk_libraries
+    ${_target_prefix}RenderingVolume
+    #${_target_prefix}Rendering${VTK_RENDERING_BACKEND}
+    ${_target_prefix}IOGeometry
+    ${_target_prefix}IOLegacy
+    ${_target_prefix}IOImage
+    ${_target_prefix}InteractionWidgets
+    ${_target_prefix}InteractionImage
+    )
+
+  vtk_module_config(ITK_VTK_LSTK
+    ${_required_vtk_libraries}
+    )
+
+  set(ITK_VTK_LSTK_LIBRARIES ${LesionSizingToolkit_LIBRARIES} ${_required_vtk_libraries})
+
+  # The VTK DICOMParser and vtkmetaio includes conflict with the ITK
+  # versions. Here we remove them from the include directories.
+  #
+  string(REGEX REPLACE "[^;]*MetaIO;"
+           "" ITK_VTK_LSTK_INCLUDE_DIRS "${ITK_VTK_LSTK_INCLUDE_DIRS}")
+  string(REGEX REPLACE "[^;]*vtkmetaio;"
+           "" ITK_VTK_LSTK_INCLUDE_DIRS "${ITK_VTK_LSTK_INCLUDE_DIRS}")
+  string(REGEX REPLACE "[^;]*DICOMParser;"
+           "" ITK_VTK_LSTK_INCLUDE_DIRS "${ITK_VTK_LSTK_INCLUDE_DIRS}")
+
+  # Add preprocessor definitions needed to use VTK.
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${ITK_VTK_LSTK_VTK_DEFINITIONS})
+
   add_subdirectory(Examples)
   add_subdirectory(Utilities)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,12 @@ set(ITK_TEST_DRIVER itkTestDriver)
 
 CreateTestDriver(LesionSizingToolkit "${LesionSizingToolkit-Test_LIBRARIES}" "${LesionSizingToolkitTests}")
 
+if(VTK_VERSION VERSION_GREATER_EQUAL "8.90.0")
+  vtk_module_autoinit(
+    TARGETS LesionSizingToolkitTestDriver
+  MODULES ${VTK_LIBRARIES})
+endif()
+
 set(TEST_DATA_ROOT "${LesionSizingToolkit_SOURCE_DIR}/Data")
 set(TEMP ${ITK_TEST_OUTPUT_DIR})
 


### PR DESCRIPTION
Fix VTK configuration errors.

Fixes:
```
CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkRenderingVolume' component is 'RenderingVolume'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkIOGeometry' component is 'IOGeometry'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkIOLegacy' component is 'IOLegacy'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkIOImage' component is 'IOImage'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkInteractionWidgets' component is
  'InteractionWidgets'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Deprecation Warning at
C:/SDKs/VTK/vtk-head-Bin/lib/cmake/vtk-8.90/vtk-config.cmake:57 (message):
  The new name for the 'vtkInteractionImage' component is 'InteractionImage'
Call Stack (most recent call first):
  C:/SDKs/VTK/vtk-head-Bin/vtk-config.cmake:1 (include)
  CMakeLists.txt:15 (find_package)

CMake Error at CMakeLists.txt:20 (include):
  include called with wrong number of arguments.  include() only takes one
  file.
```

raised when configuring the module against ITK and VTK master.