### PR TITLE
COMP: Fix unused type alias warnings

### DIFF
--- a/test/itkSegmentationModuleTest1.cxx
+++ b/test/itkSegmentationModuleTest1.cxx
@@ -26,7 +26,6 @@ int itkSegmentationModuleTest1( int itkNotUsed(argc), char * itkNotUsed(argv) []
   constexpr unsigned int Dimension = 3;
 
   using SegmentationModuleType = itk::SegmentationModule< Dimension >;
-  using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 

--- a/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
@@ -26,7 +26,6 @@ int itkSinglePhaseLevelSetSegmentationModuleTest1( int itkNotUsed(argc), char * 
   constexpr unsigned int Dimension = 3;
 
   using SegmentationModuleType = itk::SinglePhaseLevelSetSegmentationModule< Dimension >;
-  using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 


### PR DESCRIPTION
Fix unused type alias warnings.

Fixes:
```
[CTest: warning matched]
/Users/Kitware/Dashboards/TestsModules/Remote/LesionSizingToolkit/test/
itkSegmentationModuleTest1.cxx:29:9:
warning: unused type alias 'SpatialObjectType' [-Wunused-local-typedef]
  using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
        ^
[CTest: warning suppressed] 1 warning generated.
```
and
```
[CTest: warning matched]
/Users/Kitware/Dashboards/TestsModules/Remote/LesionSizingToolkit/test/
itkSinglePhaseLevelSetSegmentationModuleTest1.cxx:29:9:
warning: unused type alias 'SpatialObjectType' [-Wunused-local-typedef]
  using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
        ^
[CTest: warning suppressed] 1 warning generated.
```

raised at
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5915102