### PR TITLE
BUG: Fix failing tests for module 

### DIFF
--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
@@ -144,11 +144,11 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * i
 
   const double percentage = 100.0 * itk::Math::abs(difference) / expectedVolume;
 
-  const double epsilon = 1e-6;
   const double allowedVolumePercentageError = 1e-1; // 0.1%
-  if (!itk::Math::FloatAlmostEqual(allowedVolumePercentageError, percentage, 10, epsilon))
+
+  if (!itk::Math::FloatAlmostEqual(percentage, 0.0, 10, allowedVolumePercentageError))
   {
-    std::cerr.precision(static_cast<int>(itk::Math::abs(std::log10(epsilon))));
+    std::cerr.precision(1 + static_cast<int>(itk::Math::abs(std::log10(allowedVolumePercentageError))));
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in volume computation" << std::endl;
     std::cerr << "Expected value " << expectedVolume << std::endl;

--- a/test/itkLesionSegmentationMethodTest2.cxx
+++ b/test/itkLesionSegmentationMethodTest2.cxx
@@ -34,7 +34,7 @@ itkLesionSegmentationMethodTest2(int itkNotUsed(argc), char * itkNotUsed(argv)[]
 
   MethodType::Pointer segmentationMethod = MethodType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, LightObject);
+  EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, ProcessObject);
 
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
 

--- a/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
@@ -59,7 +59,7 @@ itkMorphologicalOpeningFeatureGeneratorTest1(int argc, char * argv[])
 
   FeatureGeneratorType::Pointer featureGenerator = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, MorphologicalOpenningFeatureGenerator, FeatureGenerator);
+  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, MorphologicalOpeningFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 


### PR DESCRIPTION
This PR addresses two main errors.

1. Two tests were given either the wrong superclass or class to compare using `EXERCISE_BASIC_OBJECT_METHODS`. Fixing this required implementing their correct superclass/class object.

2. For `itkGrayscaleImageSegmentationVolumeEstimatorTest1` the test compares the percent error of its volume estimation with 1e-1 (0.1%). In actuality, this should compare 0.0% with the percent error and verify their absolute difference is below .1%. This address #38. 