### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkBinaryThresholdFeatureGenerator.h
+++ b/include/itkBinaryThresholdFeatureGenerator.h
@@ -42,7 +42,7 @@ template <unsigned int NDimension>
 class BinaryThresholdFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryThresholdFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryThresholdFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = BinaryThresholdFeatureGenerator;

--- a/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
@@ -68,7 +68,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT CannyEdgesDistanceAdvectionFieldFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceAdvectionFieldFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(CannyEdgesDistanceAdvectionFieldFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = CannyEdgesDistanceAdvectionFieldFeatureGenerator;

--- a/include/itkCannyEdgesDistanceFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceFeatureGenerator.h
@@ -63,7 +63,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT CannyEdgesDistanceFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesDistanceFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(CannyEdgesDistanceFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = CannyEdgesDistanceFeatureGenerator;

--- a/include/itkCannyEdgesFeatureGenerator.h
+++ b/include/itkCannyEdgesFeatureGenerator.h
@@ -61,7 +61,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT CannyEdgesFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CannyEdgesFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(CannyEdgesFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = CannyEdgesFeatureGenerator;

--- a/include/itkConfidenceConnectedSegmentationModule.h
+++ b/include/itkConfidenceConnectedSegmentationModule.h
@@ -37,7 +37,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT ConfidenceConnectedSegmentationModule : public RegionGrowingSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConfidenceConnectedSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(ConfidenceConnectedSegmentationModule);
 
   /** Standard class type alias. */
   using Self = ConfidenceConnectedSegmentationModule;

--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -37,7 +37,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT ConnectedThresholdSegmentationModule : public RegionGrowingSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConnectedThresholdSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(ConnectedThresholdSegmentationModule);
 
   /** Standard class type alias. */
   using Self = ConnectedThresholdSegmentationModule;

--- a/include/itkDescoteauxSheetnessFeatureGenerator.h
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.h
@@ -45,7 +45,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT DescoteauxSheetnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxSheetnessFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(DescoteauxSheetnessFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = DescoteauxSheetnessFeatureGenerator;

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -188,7 +188,7 @@ class ITK_TEMPLATE_EXPORT DescoteauxSheetnessImageFilter
       Function::Sheetness<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(DescoteauxSheetnessImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(DescoteauxSheetnessImageFilter);
 
   /** Standard class type alias. */
   using Self = DescoteauxSheetnessImageFilter;

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -40,7 +40,7 @@ class ITK_TEMPLATE_EXPORT FastMarchingAndGeodesicActiveContourLevelSetSegmentati
   : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule);
 
   /** Standard class type alias. */
   using Self = FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule;

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
@@ -40,7 +40,7 @@ class ITK_TEMPLATE_EXPORT FastMarchingAndShapeDetectionLevelSetSegmentationModul
   : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingAndShapeDetectionLevelSetSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(FastMarchingAndShapeDetectionLevelSetSegmentationModule);
 
   /** Standard class type alias. */
   using Self = FastMarchingAndShapeDetectionLevelSetSegmentationModule;

--- a/include/itkFastMarchingSegmentationModule.h
+++ b/include/itkFastMarchingSegmentationModule.h
@@ -39,7 +39,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT FastMarchingSegmentationModule : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FastMarchingSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(FastMarchingSegmentationModule);
 
   /** Standard class type alias. */
   using Self = FastMarchingSegmentationModule;

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -41,7 +41,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT FeatureAggregator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FeatureAggregator);
+  ITK_DISALLOW_COPY_AND_MOVE(FeatureAggregator);
 
   /** Standard class type alias. */
   using Self = FeatureAggregator;

--- a/include/itkFeatureGenerator.h
+++ b/include/itkFeatureGenerator.h
@@ -41,7 +41,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT FeatureGenerator : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(FeatureGenerator);
 
   /** Standard class type alias. */
   using Self = FeatureGenerator;

--- a/include/itkFrangiTubularnessFeatureGenerator.h
+++ b/include/itkFrangiTubularnessFeatureGenerator.h
@@ -43,7 +43,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT FrangiTubularnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrangiTubularnessFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(FrangiTubularnessFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = FrangiTubularnessFeatureGenerator;

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -196,7 +196,7 @@ class ITK_TEMPLATE_EXPORT FrangiTubularnessImageFilter
       Function::Tubularness<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrangiTubularnessImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FrangiTubularnessImageFilter);
 
   /** Standard class type alias. */
   using Self = FrangiTubularnessImageFilter;

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -38,7 +38,7 @@ class ITK_TEMPLATE_EXPORT GeodesicActiveContourLevelSetSegmentationModule
   : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GeodesicActiveContourLevelSetSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(GeodesicActiveContourLevelSetSegmentationModule);
 
   /** Standard class type alias. */
   using Self = GeodesicActiveContourLevelSetSegmentationModule;

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
@@ -43,7 +43,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT GradientMagnitudeSigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GradientMagnitudeSigmoidFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(GradientMagnitudeSigmoidFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = GradientMagnitudeSigmoidFeatureGenerator;

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.h
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.h
@@ -44,7 +44,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT GrayscaleImageSegmentationVolumeEstimator : public SegmentationVolumeEstimator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GrayscaleImageSegmentationVolumeEstimator);
+  ITK_DISALLOW_COPY_AND_MOVE(GrayscaleImageSegmentationVolumeEstimator);
 
   /** Standard class type alias. */
   using Self = GrayscaleImageSegmentationVolumeEstimator;

--- a/include/itkIsotropicResampler.h
+++ b/include/itkIsotropicResampler.h
@@ -39,7 +39,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT IsotropicResampler : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicResampler);
+  ITK_DISALLOW_COPY_AND_MOVE(IsotropicResampler);
 
   /** Standard class type alias. */
   using Self = IsotropicResampler;

--- a/include/itkIsotropicResamplerImageFilter.h
+++ b/include/itkIsotropicResamplerImageFilter.h
@@ -39,7 +39,7 @@ template <typename TInputImage, typename TOutputImage>
 class IsotropicResamplerImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicResamplerImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(IsotropicResamplerImageFilter);
 
   /** Standard "Self" & Superclass type alias.  */
   using Self = IsotropicResamplerImageFilter;

--- a/include/itkLandmarksReader.h
+++ b/include/itkLandmarksReader.h
@@ -38,7 +38,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT LandmarksReader : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LandmarksReader);
+  ITK_DISALLOW_COPY_AND_MOVE(LandmarksReader);
 
   /** Standard class type alias. */
   using Self = LandmarksReader;

--- a/include/itkLesionSegmentationMethod.h
+++ b/include/itkLesionSegmentationMethod.h
@@ -44,7 +44,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT LesionSegmentationMethod : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LesionSegmentationMethod);
+  ITK_DISALLOW_COPY_AND_MOVE(LesionSegmentationMethod);
 
   /** Standard class type alias. */
   using Self = LesionSegmentationMethod;

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -178,7 +178,7 @@ class ITK_TEMPLATE_EXPORT LocalStructureImageFilter
       Function::LocalStructure<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LocalStructureImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LocalStructureImageFilter);
 
   /** Standard class type alias. */
   using Self = LocalStructureImageFilter;

--- a/include/itkLungWallFeatureGenerator.h
+++ b/include/itkLungWallFeatureGenerator.h
@@ -44,7 +44,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT LungWallFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LungWallFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(LungWallFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = LungWallFeatureGenerator;

--- a/include/itkMaximumFeatureAggregator.h
+++ b/include/itkMaximumFeatureAggregator.h
@@ -43,7 +43,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT MaximumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MaximumFeatureAggregator);
+  ITK_DISALLOW_COPY_AND_MOVE(MaximumFeatureAggregator);
 
   /** Standard class type alias. */
   using Self = MaximumFeatureAggregator;

--- a/include/itkMinimumFeatureAggregator.h
+++ b/include/itkMinimumFeatureAggregator.h
@@ -43,7 +43,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT MinimumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MinimumFeatureAggregator);
+  ITK_DISALLOW_COPY_AND_MOVE(MinimumFeatureAggregator);
 
   /** Standard class type alias. */
   using Self = MinimumFeatureAggregator;

--- a/include/itkMorphologicalOpeningFeatureGenerator.h
+++ b/include/itkMorphologicalOpeningFeatureGenerator.h
@@ -47,7 +47,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT MorphologicalOpeningFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalOpeningFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphologicalOpeningFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = MorphologicalOpeningFeatureGenerator;

--- a/include/itkRegionCompetitionImageFilter.h
+++ b/include/itkRegionCompetitionImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage>
 class RegionCompetitionImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionCompetitionImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionCompetitionImageFilter);
 
   /** Standard class type alias. */
   using Self = RegionCompetitionImageFilter;

--- a/include/itkRegionGrowingSegmentationModule.h
+++ b/include/itkRegionGrowingSegmentationModule.h
@@ -37,7 +37,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT RegionGrowingSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegionGrowingSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(RegionGrowingSegmentationModule);
 
   /** Standard class type alias. */
   using Self = RegionGrowingSegmentationModule;

--- a/include/itkSatoLocalStructureFeatureGenerator.h
+++ b/include/itkSatoLocalStructureFeatureGenerator.h
@@ -43,7 +43,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SatoLocalStructureFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SatoLocalStructureFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(SatoLocalStructureFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = SatoLocalStructureFeatureGenerator;

--- a/include/itkSatoVesselnessFeatureGenerator.h
+++ b/include/itkSatoVesselnessFeatureGenerator.h
@@ -45,7 +45,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SatoVesselnessFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(SatoVesselnessFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = SatoVesselnessFeatureGenerator;

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.h
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.h
@@ -40,7 +40,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SatoVesselnessSigmoidFeatureGenerator : public SatoVesselnessFeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SatoVesselnessSigmoidFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(SatoVesselnessSigmoidFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = SatoVesselnessSigmoidFeatureGenerator;

--- a/include/itkSegmentationModule.h
+++ b/include/itkSegmentationModule.h
@@ -41,7 +41,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SegmentationModule : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(SegmentationModule);
 
   /** Standard class type alias. */
   using Self = SegmentationModule;

--- a/include/itkSegmentationVolumeEstimator.h
+++ b/include/itkSegmentationVolumeEstimator.h
@@ -39,7 +39,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SegmentationVolumeEstimator : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SegmentationVolumeEstimator);
+  ITK_DISALLOW_COPY_AND_MOVE(SegmentationVolumeEstimator);
 
   /** Standard class type alias. */
   using Self = SegmentationVolumeEstimator;

--- a/include/itkShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.h
@@ -38,7 +38,7 @@ class ITK_TEMPLATE_EXPORT ShapeDetectionLevelSetSegmentationModule
   : public SinglePhaseLevelSetSegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ShapeDetectionLevelSetSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(ShapeDetectionLevelSetSegmentationModule);
 
   /** Standard class type alias. */
   using Self = ShapeDetectionLevelSetSegmentationModule;

--- a/include/itkSigmoidFeatureGenerator.h
+++ b/include/itkSigmoidFeatureGenerator.h
@@ -44,7 +44,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SigmoidFeatureGenerator : public FeatureGenerator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SigmoidFeatureGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(SigmoidFeatureGenerator);
 
   /** Standard class type alias. */
   using Self = SigmoidFeatureGenerator;

--- a/include/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.h
@@ -36,7 +36,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT SinglePhaseLevelSetSegmentationModule : public SegmentationModule<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SinglePhaseLevelSetSegmentationModule);
+  ITK_DISALLOW_COPY_AND_MOVE(SinglePhaseLevelSetSegmentationModule);
 
   /** Standard class type alias. */
   using Self = SinglePhaseLevelSetSegmentationModule;

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -77,7 +77,7 @@ class ITK_TEMPLATE_EXPORT VesselEnhancingDiffusion3DImageFilter
 {
 
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VesselEnhancingDiffusion3DImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VesselEnhancingDiffusion3DImageFilter);
 
   using Precision = float;
   using ImageType = Image<PixelType, NDimension>;

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -42,7 +42,7 @@ class ITK_TEMPLATE_EXPORT VotingBinaryHoleFillFloodingImageFilter
   : public VotingBinaryImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VotingBinaryHoleFillFloodingImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VotingBinaryHoleFillFloodingImageFilter);
 
   /** Standard class type alias. */
   using Self = VotingBinaryHoleFillFloodingImageFilter;

--- a/include/itkWeightedSumFeatureAggregator.h
+++ b/include/itkWeightedSumFeatureAggregator.h
@@ -45,7 +45,7 @@ template <unsigned int NDimension>
 class ITK_TEMPLATE_EXPORT WeightedSumFeatureAggregator : public FeatureAggregator<NDimension>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WeightedSumFeatureAggregator);
+  ITK_DISALLOW_COPY_AND_MOVE(WeightedSumFeatureAggregator);
 
   /** Standard class type alias. */
   using Self = WeightedSumFeatureAggregator;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.