### PR TITLE
STYLE: Rename testing macros

### DIFF
--- a/test/LandmarkSpatialObjectWriterTest.cxx
+++ b/test/LandmarkSpatialObjectWriterTest.cxx
@@ -67,7 +67,7 @@ LandmarkSpatialObjectWriterTest(int itkNotUsed(argc), char * argv[])
   writer->SetFileName(argv[1]);
   writer->SetBinaryPoints(false);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
+++ b/test/itkBinaryThresholdFeatureGeneratorTest1.cxx
@@ -51,14 +51,14 @@ itkBinaryThresholdFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using BinaryThresholdFeatureGeneratorType = itk::BinaryThresholdFeatureGenerator<Dimension>;
   using SpatialObjectType = BinaryThresholdFeatureGeneratorType::SpatialObjectType;
 
   BinaryThresholdFeatureGeneratorType::Pointer featureGenerator = BinaryThresholdFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, BinaryThresholdFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, BinaryThresholdFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -77,9 +77,9 @@ itkBinaryThresholdFeatureGeneratorTest1(int argc, char * argv[])
     threshold = std::stod(argv[3]);
   }
   featureGenerator->SetThreshold(threshold);
-  TEST_SET_GET_VALUE(threshold, featureGenerator->GetThreshold());
+  ITK_TEST_SET_GET_VALUE(threshold, featureGenerator->GetThreshold());
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
@@ -94,7 +94,7 @@ itkBinaryThresholdFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
@@ -53,7 +53,7 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using CannyEdgesDistanceAdvectionFieldFeatureGeneratorType =
@@ -63,7 +63,7 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
   CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::Pointer featureGenerator =
     CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesDistanceAdvectionFieldFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesDistanceAdvectionFieldFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -83,7 +83,7 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double upperThreshold =
     itk::NumericTraits<CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::InternalPixelType>::max();
@@ -92,7 +92,7 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
     upperThreshold = std::stod(argv[4]);
   }
   featureGenerator->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
 
   double lowerThreshold =
     itk::NumericTraits<CannyEdgesDistanceAdvectionFieldFeatureGeneratorType::InternalPixelType>::min();
@@ -101,10 +101,10 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
     lowerThreshold = std::stod(argv[5]);
   }
   featureGenerator->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -120,7 +120,7 @@ itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1(int argc, char * argv[]
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
@@ -50,7 +50,7 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using CannyEdgesDistanceFeatureGeneratorType = itk::CannyEdgesDistanceFeatureGenerator<Dimension>;
@@ -58,7 +58,7 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
 
   CannyEdgesDistanceFeatureGeneratorType::Pointer featureGenerator = CannyEdgesDistanceFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesDistanceFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesDistanceFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -76,7 +76,7 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double upperThreshold = 200;
   if (argc > 4)
@@ -84,7 +84,7 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
     upperThreshold = std::stod(argv[4]);
   }
   featureGenerator->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
 
   double lowerThreshold = 100;
   if (argc > 5)
@@ -92,9 +92,9 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
     lowerThreshold = std::stod(argv[5]);
   }
   featureGenerator->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -110,7 +110,7 @@ itkCannyEdgesDistanceFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkCannyEdgesFeatureGeneratorTest1.cxx
+++ b/test/itkCannyEdgesFeatureGeneratorTest1.cxx
@@ -50,14 +50,14 @@ itkCannyEdgesFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using CannyEdgesFeatureGeneratorType = itk::CannyEdgesFeatureGenerator<Dimension>;
   using SpatialObjectType = CannyEdgesFeatureGeneratorType::SpatialObjectType;
 
   CannyEdgesFeatureGeneratorType::Pointer featureGenerator = CannyEdgesFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, CannyEdgesFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -76,7 +76,7 @@ itkCannyEdgesFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double upperThreshold = 200;
   if (argc > 4)
@@ -84,7 +84,7 @@ itkCannyEdgesFeatureGeneratorTest1(int argc, char * argv[])
     upperThreshold = std::stod(argv[4]);
   }
   featureGenerator->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, featureGenerator->GetUpperThreshold());
 
   double lowerThreshold = 100;
   if (argc > 5)
@@ -92,9 +92,9 @@ itkCannyEdgesFeatureGeneratorTest1(int argc, char * argv[])
     lowerThreshold = std::stod(argv[5]);
   }
   featureGenerator->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, featureGenerator->GetLowerThreshold());
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -110,7 +110,7 @@ itkCannyEdgesFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
+++ b/test/itkConfidenceConnectedSegmentationModuleTest1.cxx
@@ -57,12 +57,12 @@ itkConfidenceConnectedSegmentationModuleTest1(int argc, char * argv[])
 
   featureReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
 
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, ConfidenceConnectedSegmentationModule, RegionGrowingSegmentationModule);
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -88,10 +88,10 @@ itkConfidenceConnectedSegmentationModuleTest1(int argc, char * argv[])
     sigmaMultiplier = std::stod(argv[4]);
   }
   segmentationModule->SetSigmaMultiplier(sigmaMultiplier);
-  TEST_SET_GET_VALUE(sigmaMultiplier, segmentationModule->GetSigmaMultiplier());
+  ITK_TEST_SET_GET_VALUE(sigmaMultiplier, segmentationModule->GetSigmaMultiplier());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -107,7 +107,7 @@ itkConfidenceConnectedSegmentationModuleTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkConnectedThresholdSegmentationModuleTest1.cxx
+++ b/test/itkConnectedThresholdSegmentationModuleTest1.cxx
@@ -51,19 +51,19 @@ itkConnectedThresholdSegmentationModuleTest1(int argc, char * argv[])
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName(argv[1]);
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
 
   featureReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
 
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, ConnectedThresholdSegmentationModule, RegionGrowingSegmentationModule);
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -89,7 +89,7 @@ itkConnectedThresholdSegmentationModuleTest1(int argc, char * argv[])
     lowerThreshold = std::stod(argv[4]);
   }
   segmentationModule->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
 
   double upperThreshold = 1000;
   if (argc > 5)
@@ -97,10 +97,10 @@ itkConnectedThresholdSegmentationModuleTest1(int argc, char * argv[])
     upperThreshold = std::stod(argv[5]);
   }
   segmentationModule->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -115,7 +115,7 @@ itkConnectedThresholdSegmentationModuleTest1(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1.cxx
@@ -44,7 +44,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using InputImageSpatialObjectType = itk::ImageSpatialObject<Dimension, InputPixelType>;
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -60,7 +60,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregator, UnaryFunctorImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregator, UnaryFunctorImageFilter);
 
   using DescoteauxSheetnessFeatureGeneratorType = itk::DescoteauxSheetnessFeatureGenerator<Dimension>;
   using SpatialObjectType = DescoteauxSheetnessFeatureGeneratorType::SpatialObjectType;
@@ -80,11 +80,11 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     featureGeneratorArray.push_back(featureGenerator);
 
     bool detectBrightSheets = std::stoi(argv[3]);
-    TEST_SET_GET_BOOLEAN(featureGenerator, DetectBrightSheets, detectBrightSheets);
+    ITK_TEST_SET_GET_BOOLEAN(featureGenerator, DetectBrightSheets, detectBrightSheets);
 
     double sigma = smallestSigma * octave;
     featureGenerator->SetSigma(sigma);
-    TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+    ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
     double sheetnessNormalization = 0.5;
     if (argc > 6)
@@ -92,7 +92,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
       sheetnessNormalization = std::stod(argv[6]);
     }
     featureGenerator->SetSheetnessNormalization(sheetnessNormalization);
-    // TEST_SET_GET_VALUE( sheetnessNormalization, featureGenerator->GetSheetnessNormalization() );
+    // ITK_TEST_SET_GET_VALUE( sheetnessNormalization, featureGenerator->GetSheetnessNormalization() );
 
     double bloobinessNormalization = 2.0;
     if (argc > 7)
@@ -100,7 +100,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
       bloobinessNormalization = std::stod(argv[7]);
     }
     featureGenerator->SetBloobinessNormalization(bloobinessNormalization);
-    // TEST_SET_GET_VALUE( bloobinessNormalization, featureGenerator->GetBloobinessNormalization() );
+    // ITK_TEST_SET_GET_VALUE( bloobinessNormalization, featureGenerator->GetBloobinessNormalization() );
 
     double noiseNormalization = 1.0;
     if (argc > 8)
@@ -108,7 +108,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
       noiseNormalization = std::stod(argv[8]);
     }
     featureGenerator->SetNoiseNormalization(noiseNormalization);
-    // TEST_SET_GET_VALUE( noiseNormalization, featureGenerator->GetNoiseNormalization() );
+    // ITK_TEST_SET_GET_VALUE( noiseNormalization, featureGenerator->GetNoiseNormalization() );
 
     octave *= 2;
 
@@ -116,7 +116,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     featureAggregator->AddFeatureGenerator(featureGenerator);
   }
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -135,7 +135,7 @@ itkDescoteauxSheetnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
+++ b/test/itkDescoteauxSheetnessFeatureGeneratorTest1.cxx
@@ -51,14 +51,14 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using DescoteauxSheetnessFeatureGeneratorType = itk::DescoteauxSheetnessFeatureGenerator<Dimension>;
   using SpatialObjectType = DescoteauxSheetnessFeatureGeneratorType::SpatialObjectType;
 
   DescoteauxSheetnessFeatureGeneratorType::Pointer featureGenerator = DescoteauxSheetnessFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, DescoteauxSheetnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, DescoteauxSheetnessFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -76,7 +76,7 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
   {
     detectBrightSheets = std::stoi(argv[3]);
   }
-  TEST_SET_GET_BOOLEAN(featureGenerator, DetectBrightSheets, detectBrightSheets);
+  ITK_TEST_SET_GET_BOOLEAN(featureGenerator, DetectBrightSheets, detectBrightSheets);
 
   double sigma = 1.0;
   if (argc > 4)
@@ -84,7 +84,7 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[4]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double sheetnessNormalization = 0.5;
   if (argc > 5)
@@ -92,7 +92,7 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
     sheetnessNormalization = std::stod(argv[5]);
   }
   featureGenerator->SetSheetnessNormalization(sheetnessNormalization);
-  TEST_SET_GET_VALUE(sheetnessNormalization, featureGenerator->GetSheetnessNormalization());
+  ITK_TEST_SET_GET_VALUE(sheetnessNormalization, featureGenerator->GetSheetnessNormalization());
 
   double bloobinessNormalization = 2.0;
   if (argc > 6)
@@ -100,7 +100,7 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
     bloobinessNormalization = std::stod(argv[6]);
   }
   featureGenerator->SetBloobinessNormalization(bloobinessNormalization);
-  TEST_SET_GET_VALUE(bloobinessNormalization, featureGenerator->GetBloobinessNormalization());
+  ITK_TEST_SET_GET_VALUE(bloobinessNormalization, featureGenerator->GetBloobinessNormalization());
 
   double noiseNormalization = 1.0;
   if (argc > 7)
@@ -108,9 +108,9 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
     noiseNormalization = std::stod(argv[7]);
   }
   featureGenerator->SetNoiseNormalization(noiseNormalization);
-  TEST_SET_GET_VALUE(noiseNormalization, featureGenerator->GetNoiseNormalization());
+  ITK_TEST_SET_GET_VALUE(noiseNormalization, featureGenerator->GetNoiseNormalization());
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -125,7 +125,7 @@ itkDescoteauxSheetnessFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkDescoteauxSheetnessImageFilterTest1.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest1.cxx
@@ -59,14 +59,14 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using FilterType = itk::DescoteauxSheetnessImageFilter<EigenValueImageType, OutputImageType>;
 
   FilterType::Pointer sheetnessFilter = FilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(sheetnessFilter, DescoteauxSheetnessImageFilter, UnaryFunctorImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(sheetnessFilter, DescoteauxSheetnessImageFilter, UnaryFunctorImageFilter);
 
   hessian->SetInput(reader->GetOutput());
   eigen->SetInput(hessian->GetOutput());
@@ -79,7 +79,7 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
     detectBrightSheets = std::stoi(argv[3]);
   }
   sheetnessFilter->SetDetectBrightSheets(detectBrightSheets);
-  // TEST_SET_GET_BOOLEAN( sheetnessFilter, DetectBrightSheets, detectBrightSheets );
+  // ITK_TEST_SET_GET_BOOLEAN( sheetnessFilter, DetectBrightSheets, detectBrightSheets );
 
   double sigma = 1.0;
   if (argc > 4)
@@ -87,7 +87,7 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
     hessian->SetSigma(std::stod(argv[4]));
   }
   hessian->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
 
   double sheetnessNormalization = 0.5;
   if (argc > 5)
@@ -95,7 +95,7 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
     sheetnessNormalization = std::stod(argv[5]);
   }
   sheetnessFilter->SetSheetnessNormalization(sheetnessNormalization);
-  // TEST_SET_GET_VALUE( sheetnessNormalization, sheetnessFilter->GetSheetnessNormalization() );
+  // ITK_TEST_SET_GET_VALUE( sheetnessNormalization, sheetnessFilter->GetSheetnessNormalization() );
 
   double bloobinessNormalization = 2.0;
   if (argc > 6)
@@ -103,7 +103,7 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
     bloobinessNormalization = std::stod(argv[6]);
   }
   sheetnessFilter->SetBloobinessNormalization(bloobinessNormalization);
-  // TEST_SET_GET_VALUE( bloobinessNormalization, sheetnessFilter->GetBloobinessNormalization() );
+  // ITK_TEST_SET_GET_VALUE( bloobinessNormalization, sheetnessFilter->GetBloobinessNormalization() );
 
   double noiseNormalization = 1.0;
   if (argc > 7)
@@ -111,13 +111,13 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
     noiseNormalization = std::stod(argv[7]);
   }
   sheetnessFilter->SetNoiseNormalization(noiseNormalization);
-  // TEST_SET_GET_VALUE( noiseNormalization, sheetnessFilter->GetNoiseNormalization() );
+  // ITK_TEST_SET_GET_VALUE( noiseNormalization, sheetnessFilter->GetNoiseNormalization() );
 
 
   eigen->SetDimension(Dimension);
 
 
-  TRY_EXPECT_NO_EXCEPTION(sheetnessFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(sheetnessFilter->Update());
 
 
   WriterType::Pointer writer = WriterType::New();
@@ -125,7 +125,7 @@ itkDescoteauxSheetnessImageFilterTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(sheetnessFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkDescoteauxSheetnessImageFilterTest2.cxx
+++ b/test/itkDescoteauxSheetnessImageFilterTest2.cxx
@@ -119,7 +119,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
 
   FilterType::Pointer sheetnessFilter = FilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(sheetnessFilter, DescoteauxSheetnessImageFilter, UnaryFunctorImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(sheetnessFilter, DescoteauxSheetnessImageFilter, UnaryFunctorImageFilter);
 
   hessian->SetInput(inputImage);
   eigen->SetInput(hessian->GetOutput());
@@ -132,7 +132,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
     detectBrightSheets = std::stoi(argv[2]);
   }
   sheetnessFilter->SetDetectBrightSheets(detectBrightSheets);
-  // TEST_SET_GET_BOOLEAN( sheetnessFilter, DetectBrightSheets, detectBrightSheets );
+  // ITK_TEST_SET_GET_BOOLEAN( sheetnessFilter, DetectBrightSheets, detectBrightSheets );
 
   double sigma = 1.0;
   if (argc > 3)
@@ -140,7 +140,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   hessian->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
 
   double sheetnessNormalization = 0.5;
   if (argc > 4)
@@ -148,7 +148,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
     sheetnessNormalization = std::stod(argv[4]);
   }
   sheetnessFilter->SetSheetnessNormalization(sheetnessNormalization);
-  // TEST_SET_GET_VALUE( sheetnessNormalization, sheetnessFilter->GetSheetnessNormalization() );
+  // ITK_TEST_SET_GET_VALUE( sheetnessNormalization, sheetnessFilter->GetSheetnessNormalization() );
 
   double bloobinessNormalization = 2.0;
   if (argc > 5)
@@ -156,7 +156,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
     bloobinessNormalization = std::stod(argv[5]);
   }
   sheetnessFilter->SetBloobinessNormalization(bloobinessNormalization);
-  // TEST_SET_GET_VALUE( bloobinessNormalization, sheetnessFilter->GetBloobinessNormalization() );
+  // ITK_TEST_SET_GET_VALUE( bloobinessNormalization, sheetnessFilter->GetBloobinessNormalization() );
 
   double noiseNormalization = 1.0;
   if (argc > 6)
@@ -164,13 +164,13 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
     noiseNormalization = std::stod(argv[6]);
   }
   sheetnessFilter->SetNoiseNormalization(noiseNormalization);
-  // TEST_SET_GET_VALUE( noiseNormalization, sheetnessFilter->GetNoiseNormalization() );
+  // ITK_TEST_SET_GET_VALUE( noiseNormalization, sheetnessFilter->GetNoiseNormalization() );
 
 
   eigen->SetDimension(Dimension);
 
 
-  TRY_EXPECT_NO_EXCEPTION(sheetnessFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(sheetnessFilter->Update());
 
 
   WriterType::Pointer writer = WriterType::New();
@@ -178,7 +178,7 @@ itkDescoteauxSheetnessImageFilterTest2(int argc, char * argv[])
   writer->SetFileName(argv[1]);
   writer->SetInput(sheetnessFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   OutputImageType::ConstPointer outputImage = sheetnessFilter->GetOutput();

--- a/test/itkFastMarchingSegmentationModuleTest1.cxx
+++ b/test/itkFastMarchingSegmentationModuleTest1.cxx
@@ -50,18 +50,18 @@ itkFastMarchingSegmentationModuleTest1(int argc, char * argv[])
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName(argv[1]);
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
   featureReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
 
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, FastMarchingSegmentationModule, SinglePhaseLevelSetSegmentationModule);
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -85,7 +85,7 @@ itkFastMarchingSegmentationModuleTest1(int argc, char * argv[])
     stoppingTime = std::stod(argv[4]);
   }
   segmentationModule->SetStoppingValue(stoppingTime);
-  TEST_SET_GET_VALUE(stoppingTime, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingTime, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 5.0;
   if (argc > 5)
@@ -93,10 +93,10 @@ itkFastMarchingSegmentationModuleTest1(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[5]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -111,7 +111,7 @@ itkFastMarchingSegmentationModuleTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkFeatureAggregatorTest1.cxx
+++ b/test/itkFeatureAggregatorTest1.cxx
@@ -146,30 +146,30 @@ itkFeatureAggregatorTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using AggregatorType = itk::FeatureAggregatorSurrogate<Dimension>;
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, FeatureAggregatorSurrogate, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, FeatureAggregatorSurrogate, FeatureAggregator);
 
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(vesselnessGenerator, SatoVesselnessSigmoidFeatureGenerator, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vesselnessGenerator, SatoVesselnessSigmoidFeatureGenerator, FeatureAggregator);
 
   using LungWallGeneratorType = itk::LungWallFeatureGenerator<Dimension>;
   LungWallGeneratorType::Pointer lungWallGenerator = LungWallGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(lungWallGenerator, LungWallFeatureGenerator, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(lungWallGenerator, LungWallFeatureGenerator, FeatureAggregator);
 
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator<Dimension>;
   SigmoidFeatureGeneratorType::Pointer sigmoidGenerator = SigmoidFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(sigmoidGenerator, SigmoidFeatureGenerator, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(sigmoidGenerator, SigmoidFeatureGenerator, FeatureAggregator);
 
   featureAggregator->AddFeatureGenerator(lungWallGenerator);
   featureAggregator->AddFeatureGenerator(vesselnessGenerator);
@@ -193,29 +193,29 @@ itkFeatureAggregatorTest1(int argc, char * argv[])
 
   LungWallGeneratorType::InputPixelType lungThreshold = -400;
   lungWallGenerator->SetLungThreshold(lungThreshold);
-  TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
+  ITK_TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
 
 
   double sigma = 1.0;
   vesselnessGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
 
   double alpha1 = 0.5;
   vesselnessGenerator->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
 
   double alpha2 = 2.0;
   vesselnessGenerator->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
 
 
   double alpha = 1.0;
   sigmoidGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
 
   double beta = -200.0;
   sigmoidGenerator->SetBeta(beta);
-  TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
+  ITK_TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
 
   using SegmentationModuleType = itk::ConnectedThresholdSegmentationModule<Dimension>;
 
@@ -228,7 +228,7 @@ itkFeatureAggregatorTest1(int argc, char * argv[])
     lowerThreshold = std::stod(argv[4]);
   }
   segmentationModule->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
 
   double upperThreshold = 1.0;
   if (argc > 5)
@@ -236,10 +236,10 @@ itkFeatureAggregatorTest1(int argc, char * argv[])
     upperThreshold = std::stod(argv[5]);
   }
   segmentationModule->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -260,7 +260,7 @@ itkFeatureAggregatorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
+++ b/test/itkFrangiTubularnessFeatureGeneratorTest1.cxx
@@ -51,14 +51,14 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using FrangiTubularnessFeatureGeneratorType = itk::FrangiTubularnessFeatureGenerator<Dimension>;
   using SpatialObjectType = FrangiTubularnessFeatureGeneratorType::SpatialObjectType;
 
   FrangiTubularnessFeatureGeneratorType::Pointer featureGenerator = FrangiTubularnessFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, FrangiTubularnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, FrangiTubularnessFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -77,7 +77,7 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double sheetnessNormalization = 0.5;
   if (argc > 4)
@@ -85,7 +85,7 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
     sheetnessNormalization = std::stod(argv[4]);
   }
   featureGenerator->SetSheetnessNormalization(sheetnessNormalization);
-  TEST_SET_GET_VALUE(sheetnessNormalization, featureGenerator->GetSheetnessNormalization());
+  ITK_TEST_SET_GET_VALUE(sheetnessNormalization, featureGenerator->GetSheetnessNormalization());
 
   double bloobinessNormalization = 2.0;
   if (argc > 5)
@@ -93,7 +93,7 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
     bloobinessNormalization = std::stod(argv[5]);
   }
   featureGenerator->SetBloobinessNormalization(bloobinessNormalization);
-  TEST_SET_GET_VALUE(bloobinessNormalization, featureGenerator->GetBloobinessNormalization());
+  ITK_TEST_SET_GET_VALUE(bloobinessNormalization, featureGenerator->GetBloobinessNormalization());
 
   double noiseNormalization = 1.0;
   if (argc > 6)
@@ -101,10 +101,10 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
     noiseNormalization = std::stod(argv[6]);
   }
   featureGenerator->SetNoiseNormalization(noiseNormalization);
-  TEST_SET_GET_VALUE(noiseNormalization, featureGenerator->GetNoiseNormalization());
+  ITK_TEST_SET_GET_VALUE(noiseNormalization, featureGenerator->GetNoiseNormalization());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -119,7 +119,7 @@ itkFrangiTubularnessFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkGeodesicActiveContourLevelSetSegmentationModuleTest1.cxx
@@ -41,7 +41,7 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, GeodesicActiveContourLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
 
 
@@ -58,11 +58,11 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
 
   inputReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputReader->Update());
 
   featureReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
 
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
@@ -84,7 +84,7 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
     advectionScaling = std::stod(argv[4]);
   }
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   double curvatureScaling = 1.0;
   if (argc > 5)
@@ -92,7 +92,7 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
     curvatureScaling = std::stod(argv[5]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 100.0;
   if (argc > 6)
@@ -100,7 +100,7 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
     propagationScaling = std::stod(argv[6]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   unsigned int maximumNumberOfIterations = 100;
   if (argc > 7)
@@ -108,10 +108,10 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
     maximumNumberOfIterations = std::stod(argv[7]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -126,7 +126,7 @@ itkGeodesicActiveContourLevelSetSegmentationModuleTest1(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkGradientMagnitudeSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkGradientMagnitudeSigmoidFeatureGeneratorTest1.cxx
@@ -51,7 +51,7 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using GradientMagnitudeSigmoidFeatureGeneratorType = itk::GradientMagnitudeSigmoidFeatureGenerator<Dimension>;
@@ -60,7 +60,7 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
   GradientMagnitudeSigmoidFeatureGeneratorType::Pointer featureGenerator =
     GradientMagnitudeSigmoidFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, GradientMagnitudeSigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, GradientMagnitudeSigmoidFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -80,7 +80,7 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double alpha = -1.0;
   if (argc > 4)
@@ -88,7 +88,7 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     alpha = std::stod(argv[4]);
   }
   featureGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
 
   double beta = 128;
   if (argc > 5)
@@ -96,10 +96,10 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     beta = std::stod(argv[5]);
   }
   featureGenerator->SetBeta(beta);
-  TEST_SET_GET_VALUE(beta, featureGenerator->GetBeta());
+  ITK_TEST_SET_GET_VALUE(beta, featureGenerator->GetBeta());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -114,7 +114,7 @@ itkGradientMagnitudeSigmoidFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest1.cxx
@@ -32,7 +32,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * i
 
   VolumeEstimatorType::Pointer volumeEstimator = VolumeEstimatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     volumeEstimator, GrayscaleImageSegmentationVolumeEstimator, SegmentationVolumeEstimator);
 
   using ImageSpatialObjectType = itk::ImageSpatialObject<Dimension>;
@@ -41,7 +41,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * i
 
   volumeEstimator->SetInput(inputObject);
 
-  TRY_EXPECT_EXCEPTION(volumeEstimator->Update());
+  ITK_TRY_EXPECT_EXCEPTION(volumeEstimator->Update());
 
 
   using InputImageType = VolumeEstimatorType::InputImageType;
@@ -114,7 +114,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * i
     ++itr;
   }
 
-  TRY_EXPECT_NO_EXCEPTION(volumeEstimator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(volumeEstimator->Update());
 
   VolumeEstimatorType::RealType volume1 = volumeEstimator->GetVolume();
 
@@ -134,7 +134,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * i
   writer->SetInput(image);
   writer->SetFileName("sphereForVolumeTest.mhd");
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   const double pi = atan(1.0) * 4.0;
 

--- a/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
+++ b/test/itkGrayscaleImageSegmentationVolumeEstimatorTest2.cxx
@@ -43,7 +43,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest2(int argc, char * argv[])
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   InputImageType::Pointer inputImage = inputImageReader->GetOutput();
   inputImage->DisconnectPipeline();
@@ -53,7 +53,7 @@ itkGrayscaleImageSegmentationVolumeEstimatorTest2(int argc, char * argv[])
 
   VolumeEstimatorType::Pointer volumeEstimator = VolumeEstimatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     volumeEstimator, GrayscaleImageSegmentationVolumeEstimator, SegmentationVolumeEstimator);
 
 

--- a/test/itkIsotropicResamplerTest1.cxx
+++ b/test/itkIsotropicResamplerTest1.cxx
@@ -51,7 +51,7 @@ itkIsotropicResamplerTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using ResampleFilterType = itk::IsotropicResampler<Dimension>;
@@ -59,7 +59,7 @@ itkIsotropicResamplerTest1(int argc, char * argv[])
 
   ResampleFilterType::Pointer resampler = ResampleFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(resampler, IsotropicResampler, ProcessObject);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(resampler, IsotropicResampler, ProcessObject);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -72,7 +72,7 @@ itkIsotropicResamplerTest1(int argc, char * argv[])
 
   resampler->SetInput(inputObject);
 
-  TRY_EXPECT_NO_EXCEPTION(resampler->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(resampler->Update());
 
 
   SpatialObjectType::ConstPointer resampledImage = resampler->GetOutput();
@@ -88,7 +88,7 @@ itkIsotropicResamplerTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLandmarksReaderTest1.cxx
+++ b/test/itkLandmarksReaderTest1.cxx
@@ -55,7 +55,7 @@ itkLandmarksReaderTest1(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   InputSpatialObjectType::ConstPointer landmarkSpatialObject1 = landmarksReader->GetOutput();
@@ -67,7 +67,7 @@ itkLandmarksReaderTest1(int argc, char * argv[])
 
   SpatialObjectReaderType::Pointer landmarkPointsReader = SpatialObjectReaderType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(landmarkPointsReader, SpatialObjectReader, Object);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(landmarkPointsReader, SpatialObjectReader, Object);
 
   landmarkPointsReader->SetFileName(argv[1]);
   landmarkPointsReader->Update();

--- a/test/itkLesionSegmentationMethodTest1.cxx
+++ b/test/itkLesionSegmentationMethodTest1.cxx
@@ -30,7 +30,7 @@ itkLesionSegmentationMethodTest1(int itkNotUsed(argc), char * itkNotUsed(argv)[]
 
   MethodType::Pointer segmentationMethod = MethodType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, ProcessObject);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, ProcessObject);
 
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
 
@@ -66,7 +66,7 @@ itkLesionSegmentationMethodTest1(int itkNotUsed(argc), char * itkNotUsed(argv)[]
 
   segmentationMethod->AddFeatureGenerator(featureGenerator);
 
-  TRY_EXPECT_EXCEPTION(segmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(segmentationMethod->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest10.cxx
+++ b/test/itkLesionSegmentationMethodTest10.cxx
@@ -66,14 +66,14 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
 
   MethodType::Pointer lesionSegmentationMethod = MethodType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(lesionSegmentationMethod, LesionSegmentationMethod, LightObject);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(lesionSegmentationMethod, LesionSegmentationMethod, LightObject);
 
 
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
@@ -121,7 +121,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
 
   resampler->SetInput(inputObject);
 
-  TRY_EXPECT_NO_EXCEPTION(resampler->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(resampler->Update());
 
 
   SpatialObjectType::ConstPointer resampledObject = resampler->GetOutput();
@@ -151,7 +151,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     maxSpacing = std::stod(argv[4]);
   }
   cannyEdgesGenerator->SetSigma(maxSpacing);
-  TEST_SET_GET_VALUE(maxSpacing, cannyEdgesGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(maxSpacing, cannyEdgesGenerator->GetSigma());
 
   double upperThreshold = 150.0;
   if (argc > 5)
@@ -159,7 +159,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     upperThreshold = std::stod(argv[5]);
   }
   cannyEdgesGenerator->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, cannyEdgesGenerator->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, cannyEdgesGenerator->GetUpperThreshold());
 
   double lowerThreshold = 75.0;
   if (argc > 6)
@@ -167,13 +167,13 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     lowerThreshold = std::stod(argv[6]);
   }
   cannyEdgesGenerator->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, cannyEdgesGenerator->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, cannyEdgesGenerator->GetLowerThreshold());
 
 
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
                                 FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
                                 SinglePhaseLevelSetSegmentationModule);
 
@@ -183,7 +183,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     maximumRMSError = std::stod(argv[7]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 8)
@@ -191,7 +191,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[8]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 9)
@@ -199,7 +199,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     curvatureScaling = std::stod(argv[9]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 500.0;
   if (argc > 10)
@@ -207,7 +207,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     propagationScaling = std::stod(argv[10]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double advectionScaling = 0.0;
   if (argc > 11)
@@ -215,7 +215,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     advectionScaling = std::stod(argv[11]);
   }
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   double stoppingValue = 5.0;
   if (argc > 12)
@@ -223,7 +223,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     stoppingValue = std::stod(argv[12]);
   }
   segmentationModule->SetStoppingValue(stoppingValue);
-  TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 0.5;
   if (argc > 13)
@@ -231,7 +231,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[13]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -266,7 +266,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   //
@@ -274,7 +274,7 @@ itkLesionSegmentationMethodTest10(int argc, char * argv[])
   //
   lesionSegmentationMethod->AddFeatureGenerator(lungWallGenerator);
 
-  TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest2.cxx
+++ b/test/itkLesionSegmentationMethodTest2.cxx
@@ -34,7 +34,7 @@ itkLesionSegmentationMethodTest2(int itkNotUsed(argc), char * itkNotUsed(argv)[]
 
   MethodType::Pointer segmentationMethod = MethodType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, ProcessObject);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationMethod, ProcessObject);
 
   using ImageMaskSpatialObjectType = itk::ImageMaskSpatialObject<Dimension>;
 
@@ -68,7 +68,7 @@ itkLesionSegmentationMethodTest2(int itkNotUsed(argc), char * itkNotUsed(argv)[]
   segmentationMethod->AddFeatureGenerator(localStructureGenerator);
   segmentationMethod->AddFeatureGenerator(gradientMagnitudeSigmoidGenerator);
 
-  TRY_EXPECT_EXCEPTION(segmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(segmentationMethod->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest3.cxx
+++ b/test/itkLesionSegmentationMethodTest3.cxx
@@ -50,7 +50,7 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using LandmarksReaderType = itk::LandmarksReader<Dimension>;
 
@@ -58,7 +58,7 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
 
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
@@ -117,7 +117,7 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, ConnectedThresholdSegmentationModule, RegionGrowingSegmentationModule);
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -129,7 +129,7 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
     lowerThreshold = std::stod(argv[4]);
   }
   segmentationModule->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, segmentationModule->GetLowerThreshold());
 
   double upperThreshold = 1.0;
   if (argc > 5)
@@ -137,12 +137,12 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
     upperThreshold = std::stod(argv[5]);
   }
   segmentationModule->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, segmentationModule->GetUpperThreshold());
 
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -163,7 +163,7 @@ itkLesionSegmentationMethodTest3(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkLesionSegmentationMethodTest4.cxx
+++ b/test/itkLesionSegmentationMethodTest4.cxx
@@ -57,7 +57,7 @@ itkLesionSegmentationMethodTest4(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
@@ -131,7 +131,7 @@ itkLesionSegmentationMethodTest4(int argc, char * argv[])
     stoppingTime = std::stod(argv[4]);
   }
   segmentationModule->SetStoppingValue(stoppingTime);
-  TEST_SET_GET_VALUE(stoppingTime, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingTime, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 5.0;
   if (argc > 5)
@@ -139,7 +139,7 @@ itkLesionSegmentationMethodTest4(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[5]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -150,12 +150,12 @@ itkLesionSegmentationMethodTest4(int argc, char * argv[])
 
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -176,7 +176,7 @@ itkLesionSegmentationMethodTest4(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   segmentationModule->Print(std::cout);

--- a/test/itkLesionSegmentationMethodTest5.cxx
+++ b/test/itkLesionSegmentationMethodTest5.cxx
@@ -58,7 +58,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
@@ -126,7 +126,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
   using SegmentationModuleType = itk::ShapeDetectionLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, ShapeDetectionLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
 
 
@@ -136,7 +136,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
     maximumRMSError = std::stod(argv[4]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 5)
@@ -144,7 +144,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[5]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 6)
@@ -152,7 +152,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
     curvatureScaling = std::stod(argv[6]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 500.0;
   if (argc > 7)
@@ -160,7 +160,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
     propagationScaling = std::stod(argv[7]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -174,7 +174,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
 
   inputSegmentationReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputSegmentationReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputSegmentationReader->Update());
 
   InputSegmentationType::Pointer inputSegmentation = inputSegmentationReader->GetOutput();
 
@@ -186,7 +186,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
 
   lesionSegmentationMethod->SetInitialSegmentation(inputImageSpatialObject);
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -207,7 +207,7 @@ itkLesionSegmentationMethodTest5(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest6.cxx
+++ b/test/itkLesionSegmentationMethodTest6.cxx
@@ -61,7 +61,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
@@ -129,7 +129,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
   using SegmentationModuleType = itk::FastMarchingAndShapeDetectionLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, FastMarchingAndShapeDetectionLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
 
 
@@ -139,7 +139,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     maximumRMSError = std::stod(argv[4]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 5)
@@ -147,7 +147,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[5]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 6)
@@ -155,7 +155,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     curvatureScaling = std::stod(argv[6]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 10.0;
   if (argc > 7)
@@ -163,7 +163,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     propagationScaling = std::stod(argv[7]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double stoppingValue = 500.0;
   if (argc > 8)
@@ -171,7 +171,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     stoppingValue = std::stod(argv[8]);
   }
   segmentationModule->SetStoppingValue(stoppingValue);
-  TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 0.5;
   if (argc > 9)
@@ -179,7 +179,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[9]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -189,12 +189,12 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
 
   landmarksReader->SetFileName(argv[1]);
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -220,7 +220,7 @@ itkLesionSegmentationMethodTest6(int argc, char * argv[])
 
   std::cout << "Name of class " << segmentationModule->GetNameOfClass() << std::endl;
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest7.cxx
+++ b/test/itkLesionSegmentationMethodTest7.cxx
@@ -61,7 +61,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
 
@@ -112,7 +112,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
                                 FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
                                 SinglePhaseLevelSetSegmentationModule);
 
@@ -123,7 +123,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     maximumRMSError = std::stod(argv[4]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 5)
@@ -131,7 +131,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[5]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 6)
@@ -139,7 +139,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     curvatureScaling = std::stod(argv[6]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 500.0;
   if (argc > 7)
@@ -147,7 +147,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     propagationScaling = std::stod(argv[7]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double advectionScaling = 0.0;
   if (argc > 8)
@@ -155,7 +155,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     advectionScaling = std::stod(argv[8]);
   }
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   double stoppingValue = 5.0;
   if (argc > 9)
@@ -163,7 +163,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     stoppingValue = std::stod(argv[9]);
   }
   segmentationModule->SetStoppingValue(stoppingValue);
-  TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 2.0;
   if (argc > 10)
@@ -171,7 +171,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[10]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -182,11 +182,11 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
 
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -205,7 +205,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   //
@@ -213,7 +213,7 @@ itkLesionSegmentationMethodTest7(int argc, char * argv[])
   //
   lesionSegmentationMethod->AddFeatureGenerator(lungWallGenerator);
 
-  TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkLesionSegmentationMethodTest8.cxx
+++ b/test/itkLesionSegmentationMethodTest8.cxx
@@ -65,7 +65,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
 
@@ -133,7 +133,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     maxSpacing = std::stod(argv[4]);
   }
   cannyEdgesGenerator->SetSigma(maxSpacing);
-  TEST_SET_GET_VALUE(maxSpacing, cannyEdgesGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(maxSpacing, cannyEdgesGenerator->GetSigma());
 
   double upperThreshold = 150.0;
   if (argc > 5)
@@ -141,7 +141,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     upperThreshold = std::stod(argv[5]);
   }
   cannyEdgesGenerator->SetUpperThreshold(upperThreshold);
-  TEST_SET_GET_VALUE(upperThreshold, cannyEdgesGenerator->GetUpperThreshold());
+  ITK_TEST_SET_GET_VALUE(upperThreshold, cannyEdgesGenerator->GetUpperThreshold());
 
   double lowerThreshold = 75.0;
   if (argc > 6)
@@ -149,13 +149,13 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     lowerThreshold = std::stod(argv[6]);
   }
   cannyEdgesGenerator->SetLowerThreshold(lowerThreshold);
-  TEST_SET_GET_VALUE(lowerThreshold, cannyEdgesGenerator->GetLowerThreshold());
+  ITK_TEST_SET_GET_VALUE(lowerThreshold, cannyEdgesGenerator->GetLowerThreshold());
 
 
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
                                 FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
                                 SinglePhaseLevelSetSegmentationModule);
 
@@ -165,7 +165,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     maximumRMSError = std::stod(argv[7]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 8)
@@ -173,7 +173,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[8]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 9)
@@ -181,7 +181,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     curvatureScaling = std::stod(argv[9]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 500.0;
   if (argc > 10)
@@ -189,7 +189,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     propagationScaling = std::stod(argv[10]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double advectionScaling = 0.0;
   if (argc > 11)
@@ -197,7 +197,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     advectionScaling = std::stod(argv[11]);
   }
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   double stoppingValue = 5.0;
   if (argc > 12)
@@ -205,7 +205,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     stoppingValue = std::stod(argv[12]);
   }
   segmentationModule->SetStoppingValue(stoppingValue);
-  TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 0.5;
   if (argc > 13)
@@ -213,7 +213,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[13]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -224,12 +224,12 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
 
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
@@ -250,7 +250,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   //
@@ -258,7 +258,7 @@ itkLesionSegmentationMethodTest8(int argc, char * argv[])
   //
   lesionSegmentationMethod->AddFeatureGenerator(lungWallGenerator);
 
-  TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLesionSegmentationMethodTest8b.cxx
+++ b/test/itkLesionSegmentationMethodTest8b.cxx
@@ -59,21 +59,21 @@ itkLesionSegmentationMethodTest8b(int argc, char * argv[])
   InputImageReaderType::Pointer inputImageReader = InputImageReaderType::New();
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   const InputImageType * inputImage = inputImageReader->GetOutput();
 
   LandmarksReaderType::Pointer landmarksReader = LandmarksReaderType::New();
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
 
   const SeedSpatialObjectType * landmarks = landmarksReader->GetOutput();
 
   SegmentationMethodType::Pointer segmentationMethod = SegmentationMethodType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationImageFilter8, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationMethod, LesionSegmentationImageFilter8, ImageToImageFilter);
 
 
   segmentationMethod->SetInput(inputImage);
@@ -86,19 +86,19 @@ itkLesionSegmentationMethodTest8b(int argc, char * argv[])
     sigmoidBeta = std::stod(argv[4]);
   }
   segmentationMethod->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, segmentationMethod->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, segmentationMethod->GetSigmoidBeta());
 
   segmentationMethod->SetResampleThickSliceData(resampleThickSliceData);
   segmentationMethod->SetUseVesselEnhancingDiffusion(useVesselEnhancingDiffusion);
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationMethod->Update());
 
   OutputWriterType::Pointer writer = OutputWriterType::New();
   writer->SetFileName(argv[3]);
   writer->SetInput(segmentationMethod->GetOutput());
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkLesionSegmentationMethodTest9.cxx
+++ b/test/itkLesionSegmentationMethodTest9.cxx
@@ -61,7 +61,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using MethodType = itk::LesionSegmentationMethod<Dimension>;
 
@@ -123,7 +123,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
   using SegmentationModuleType = itk::FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule<Dimension>;
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule,
                                 FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule,
                                 SinglePhaseLevelSetSegmentationModule);
 
@@ -134,7 +134,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     maximumRMSError = std::stod(argv[4]);
   }
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   unsigned int maximumNumberOfIterations = 300;
   if (argc > 5)
@@ -142,7 +142,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[5]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
   double curvatureScaling = 1.0;
   if (argc > 6)
@@ -150,7 +150,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     curvatureScaling = std::stod(argv[6]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   double propagationScaling = 500.0;
   if (argc > 7)
@@ -158,7 +158,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     propagationScaling = std::stod(argv[7]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double advectionScaling = 0.0;
   if (argc > 8)
@@ -166,7 +166,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     advectionScaling = std::stod(argv[8]);
   }
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   double stoppingValue = 5.0;
   if (argc > 9)
@@ -174,7 +174,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     stoppingValue = std::stod(argv[9]);
   }
   segmentationModule->SetStoppingValue(stoppingValue);
-  TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
+  ITK_TEST_SET_GET_VALUE(stoppingValue, segmentationModule->GetStoppingValue());
 
   double distanceFromSeeds = 2.5;
   if (argc > 10)
@@ -182,7 +182,7 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
     distanceFromSeeds = std::stod(argv[10]);
   }
   segmentationModule->SetDistanceFromSeeds(distanceFromSeeds);
-  TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
+  ITK_TEST_SET_GET_VALUE(distanceFromSeeds, segmentationModule->GetDistanceFromSeeds());
 
 
   lesionSegmentationMethod->SetSegmentationModule(segmentationModule);
@@ -193,11 +193,11 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
 
   landmarksReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(landmarksReader->Update());
 
   lesionSegmentationMethod->SetInitialSegmentation(landmarksReader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(lesionSegmentationMethod->Update());
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   using OutputSpatialObjectType = SegmentationModuleType::OutputSpatialObjectType;
@@ -215,14 +215,14 @@ itkLesionSegmentationMethodTest9(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   //
   // Exercise the exception on the number of feature generators
   //
   lesionSegmentationMethod->AddFeatureGenerator(lungWallGenerator);
 
-  TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
+  ITK_TRY_EXPECT_EXCEPTION(lesionSegmentationMethod->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkLocalStructureImageFilterTest1.cxx
+++ b/test/itkLocalStructureImageFilterTest1.cxx
@@ -63,7 +63,7 @@ itkLocalStructureImageFilterTest1(int argc, char * argv[])
 
   LocalStructureFilterType::Pointer localStructure = LocalStructureFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(localStructure, LocalStructureImageFilter, UnaryFunctorImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(localStructure, LocalStructureImageFilter, UnaryFunctorImageFilter);
 
   hessian->SetInput(reader->GetOutput());
   eigen->SetInput(hessian->GetOutput());
@@ -76,7 +76,7 @@ itkLocalStructureImageFilterTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   hessian->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, hessian->GetSigma());
 
   double alpha = 0.25;
   if (argc > 4)
@@ -84,7 +84,7 @@ itkLocalStructureImageFilterTest1(int argc, char * argv[])
     alpha = std::stod(argv[4]);
   }
   localStructure->SetAlpha(alpha);
-  // TEST_SET_GET_VALUE( alpha, localStructure->GetAlpha() );
+  // ITK_TEST_SET_GET_VALUE( alpha, localStructure->GetAlpha() );
 
   double gamma = 0.5;
   if (argc > 5)
@@ -92,7 +92,7 @@ itkLocalStructureImageFilterTest1(int argc, char * argv[])
     gamma = std::stod(argv[5]);
   }
   localStructure->SetGamma(gamma);
-  // TEST_SET_GET_VALUE( gamma, localStructure->GetGamma() );
+  // ITK_TEST_SET_GET_VALUE( gamma, localStructure->GetGamma() );
 
   eigen->SetDimension(Dimension);
 
@@ -101,7 +101,7 @@ itkLocalStructureImageFilterTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(localStructure->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkLungWallFeatureGeneratorTest1.cxx
+++ b/test/itkLungWallFeatureGeneratorTest1.cxx
@@ -51,14 +51,14 @@ itkLungWallFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using LungWallFeatureGeneratorType = itk::LungWallFeatureGenerator<Dimension>;
   using SpatialObjectType = LungWallFeatureGeneratorType::SpatialObjectType;
 
   LungWallFeatureGeneratorType::Pointer featureGenerator = LungWallFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, LungWallFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, LungWallFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -77,9 +77,9 @@ itkLungWallFeatureGeneratorTest1(int argc, char * argv[])
     lungThreshold = std::stoi(argv[3]);
   }
   featureGenerator->SetLungThreshold(lungThreshold);
-  TEST_SET_GET_VALUE(lungThreshold, featureGenerator->GetLungThreshold());
+  ITK_TEST_SET_GET_VALUE(lungThreshold, featureGenerator->GetLungThreshold());
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -95,7 +95,7 @@ itkLungWallFeatureGeneratorTest1(int argc, char * argv[])
   writer->UseCompressionOn();
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkMaximumFeatureAggregatorTest1.cxx
+++ b/test/itkMaximumFeatureAggregatorTest1.cxx
@@ -47,13 +47,13 @@ itkMaximumFeatureAggregatorTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using AggregatorType = itk::MaximumFeatureAggregator<Dimension>;
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregator, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregator, FeatureAggregator);
 
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
@@ -94,7 +94,7 @@ itkMaximumFeatureAggregatorTest1(int argc, char * argv[])
   sigmoidGenerator->SetBeta(-200.0);
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
@@ -113,7 +113,7 @@ itkMaximumFeatureAggregatorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkMaximumFeatureAggregatorTest2.cxx
+++ b/test/itkMaximumFeatureAggregatorTest2.cxx
@@ -78,13 +78,13 @@ itkMaximumFeatureAggregatorTest2(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using AggregatorType = itk::MaximumFeatureAggregatorSurrogage;
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregatorSurrogage, MaximumFeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MaximumFeatureAggregatorSurrogage, MaximumFeatureAggregator);
 
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
@@ -118,31 +118,31 @@ itkMaximumFeatureAggregatorTest2(int argc, char * argv[])
 
   LungWallGeneratorType::InputPixelType lungThreshold = -400;
   lungWallGenerator->SetLungThreshold(lungThreshold);
-  TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
+  ITK_TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
 
 
   double sigma = 1.0;
   vesselnessGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
 
   double alpha1 = 0.5;
   vesselnessGenerator->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
 
   double alpha2 = 2.0;
   vesselnessGenerator->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
 
   double alpha = 1.0;
   sigmoidGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
 
   double beta = -200.0;
   sigmoidGenerator->SetBeta(beta);
-  TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
+  ITK_TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -160,7 +160,7 @@ itkMaximumFeatureAggregatorTest2(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   //
@@ -187,7 +187,7 @@ itkMaximumFeatureAggregatorTest2(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  TRY_EXPECT_EXCEPTION(featureAggregator->GetInputFeature(3));
+  ITK_TRY_EXPECT_EXCEPTION(featureAggregator->GetInputFeature(3));
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkMinimumFeatureAggregatorTest1.cxx
+++ b/test/itkMinimumFeatureAggregatorTest1.cxx
@@ -46,13 +46,13 @@ itkMinimumFeatureAggregatorTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using AggregatorType = itk::MinimumFeatureAggregator<Dimension>;
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MinimumFeatureAggregator, FeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MinimumFeatureAggregator, FeatureAggregator);
 
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
   VesselnessGeneratorType::Pointer vesselnessGenerator = VesselnessGeneratorType::New();
@@ -103,7 +103,7 @@ itkMinimumFeatureAggregatorTest1(int argc, char * argv[])
   cannyEdgesGenerator->SetUpperThreshold(150.0);
   cannyEdgesGenerator->SetLowerThreshold(75.0);
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -121,7 +121,7 @@ itkMinimumFeatureAggregatorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkMinimumFeatureAggregatorTest2.cxx
+++ b/test/itkMinimumFeatureAggregatorTest2.cxx
@@ -77,13 +77,13 @@ itkMinimumFeatureAggregatorTest2(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
   using AggregatorType = itk::MinimumFeatureAggregatorSurrogate;
 
   AggregatorType::Pointer featureAggregator = AggregatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MinimumFeatureAggregatorSurrogate, MinimumFeatureAggregator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureAggregator, MinimumFeatureAggregatorSurrogate, MinimumFeatureAggregator);
 
 
   using VesselnessGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
@@ -118,31 +118,31 @@ itkMinimumFeatureAggregatorTest2(int argc, char * argv[])
 
   LungWallGeneratorType::InputPixelType lungThreshold = -400;
   lungWallGenerator->SetLungThreshold(lungThreshold);
-  TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
+  ITK_TEST_SET_GET_VALUE(lungThreshold, lungWallGenerator->GetLungThreshold());
 
 
   double sigma = 1.0;
   vesselnessGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, vesselnessGenerator->GetSigma());
 
   double alpha1 = 0.5;
   vesselnessGenerator->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, vesselnessGenerator->GetAlpha1());
 
   double alpha2 = 2.0;
   vesselnessGenerator->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, vesselnessGenerator->GetAlpha2());
 
   double alpha = 1.0;
   sigmoidGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, sigmoidGenerator->GetAlpha());
 
   double beta = -200.0;
   sigmoidGenerator->SetBeta(beta);
-  TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
+  ITK_TEST_SET_GET_VALUE(beta, sigmoidGenerator->GetBeta());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
 
@@ -160,7 +160,7 @@ itkMinimumFeatureAggregatorTest2(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   //
   // Exercise GetInputFeature()
@@ -186,7 +186,7 @@ itkMinimumFeatureAggregatorTest2(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  TRY_EXPECT_EXCEPTION(featureAggregator->GetInputFeature(3));
+  ITK_TRY_EXPECT_EXCEPTION(featureAggregator->GetInputFeature(3));
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
+++ b/test/itkMorphologicalOpeningFeatureGeneratorTest1.cxx
@@ -52,14 +52,14 @@ itkMorphologicalOpeningFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using FeatureGeneratorType = itk::MorphologicalOpeningFeatureGenerator<Dimension>;
   using SpatialObjectType = FeatureGeneratorType::SpatialObjectType;
 
   FeatureGeneratorType::Pointer featureGenerator = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, MorphologicalOpeningFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, MorphologicalOpeningFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -77,10 +77,10 @@ itkMorphologicalOpeningFeatureGeneratorTest1(int argc, char * argv[])
     lungThreshold = std::stoi(argv[3]);
   }
   featureGenerator->SetLungThreshold(lungThreshold);
-  TEST_SET_GET_VALUE(lungThreshold, featureGenerator->GetLungThreshold());
+  ITK_TEST_SET_GET_VALUE(lungThreshold, featureGenerator->GetLungThreshold());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
@@ -95,7 +95,7 @@ itkMorphologicalOpeningFeatureGeneratorTest1(int argc, char * argv[])
   writer->UseCompressionOn();
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkRegionCompetitionImageFilterTest1.cxx
+++ b/test/itkRegionCompetitionImageFilterTest1.cxx
@@ -148,14 +148,14 @@ itkRegionCompetitionImageFilterTest1(int itkNotUsed(argc), char * itkNotUsed(arg
   writer->SetInput(inputImage);
   writer->SetFileName("inputCompetitionImage.mha");
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   thresholderFilter->SetInput(inputImage);
   thresholderFilter->SetUpperThreshold(2000);
   thresholderFilter->SetLowerThreshold(400);
 
-  TRY_EXPECT_NO_EXCEPTION(thresholderFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(thresholderFilter->Update());
 
   componentsFilter->SetInput(thresholderFilter->GetOutput());
   relabelerFilter->SetInput(componentsFilter->GetOutput());
@@ -168,20 +168,20 @@ itkRegionCompetitionImageFilterTest1(int itkNotUsed(argc), char * itkNotUsed(arg
   labelWriter->SetInput(relabelerFilter->GetOutput());
   labelWriter->SetFileName("labeledImage.mha");
 
-  TRY_EXPECT_NO_EXCEPTION(labelWriter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(labelWriter->Update());
 
 
   competitionFilter->SetInput(inputImage);
   competitionFilter->SetInputLabels(labelImagePt);
 
-  TRY_EXPECT_NO_EXCEPTION(competitionFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(competitionFilter->Update());
 
 
   // Write the output image
   labelWriter->SetInput(competitionFilter->GetOutput());
   labelWriter->SetFileName("labeledSegmentedImage.mha");
 
-  TRY_EXPECT_NO_EXCEPTION(labelWriter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(labelWriter->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkSatoLocalStructureFeatureGeneratorTest1.cxx
+++ b/test/itkSatoLocalStructureFeatureGeneratorTest1.cxx
@@ -51,7 +51,7 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using SatoLocalStructureFeatureGeneratorType = itk::SatoLocalStructureFeatureGenerator<Dimension>;
@@ -59,7 +59,7 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
 
   SatoLocalStructureFeatureGeneratorType::Pointer featureGenerator = SatoLocalStructureFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SatoLocalStructureFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SatoLocalStructureFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -79,7 +79,7 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double alpha = 0.5;
   if (argc > 4)
@@ -87,7 +87,7 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
     alpha = std::stod(argv[4]);
   }
   featureGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
 
   double gamma = 2.0;
   if (argc > 5)
@@ -95,10 +95,10 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
     gamma = std::stod(argv[5]);
   }
   featureGenerator->SetGamma(gamma);
-  TEST_SET_GET_VALUE(gamma, featureGenerator->GetGamma());
+  ITK_TEST_SET_GET_VALUE(gamma, featureGenerator->GetGamma());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -113,7 +113,7 @@ itkSatoLocalStructureFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkSatoVesselnessFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkSatoVesselnessFeatureGeneratorMultiScaleTest1.cxx
@@ -44,7 +44,7 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using AggregatorType = itk::MaximumFeatureAggregator<Dimension>;
@@ -56,18 +56,18 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   FeatureGeneratorType::Pointer featureGenerator1 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator1, SatoVesselnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator1, SatoVesselnessFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator2 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator2, SatoVesselnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator2, SatoVesselnessFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator3 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator3, SatoVesselnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator3, SatoVesselnessFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator4 = FeatureGeneratorType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator4, SatoVesselnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator4, SatoVesselnessFeatureGenerator, FeatureGenerator);
 
 
   double smallestSigma = 1.0;
@@ -76,16 +76,16 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     smallestSigma = std::stod(argv[3]);
   }
   featureGenerator1->SetSigma(smallestSigma);
-  TEST_SET_GET_VALUE(smallestSigma, featureGenerator1->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma, featureGenerator1->GetSigma());
   double smallestSigma2 = smallestSigma * 2.0;
   featureGenerator2->SetSigma(smallestSigma2);
-  TEST_SET_GET_VALUE(smallestSigma2, featureGenerator2->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma2, featureGenerator2->GetSigma());
   double smallestSigma3 = smallestSigma * 4.0;
   featureGenerator3->SetSigma(smallestSigma3);
-  TEST_SET_GET_VALUE(smallestSigma3, featureGenerator3->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma3, featureGenerator3->GetSigma());
   double smallestSigma4 = smallestSigma * 8.0;
   featureGenerator4->SetSigma(smallestSigma4);
-  TEST_SET_GET_VALUE(smallestSigma4, featureGenerator4->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma4, featureGenerator4->GetSigma());
 
   double alpha1 = 0.5;
   if (argc > 4)
@@ -93,13 +93,13 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     alpha1 = std::stod(argv[4]);
   }
   featureGenerator1->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator1->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator1->GetAlpha1());
   featureGenerator2->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator2->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator2->GetAlpha1());
   featureGenerator3->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator3->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator3->GetAlpha1());
   featureGenerator4->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator4->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator4->GetAlpha1());
 
   double alpha2 = 2.0;
   if (argc > 5)
@@ -107,13 +107,13 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     alpha2 = std::stod(argv[5]);
   }
   featureGenerator1->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
   featureGenerator2->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
   featureGenerator3->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
   featureGenerator4->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
 
 
   using SpatialObjectType = AggregatorType::SpatialObjectType;
@@ -137,7 +137,7 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   featureAggregator->AddFeatureGenerator(featureGenerator3);
   featureAggregator->AddFeatureGenerator(featureGenerator4);
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
@@ -157,7 +157,7 @@ itkSatoVesselnessFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   featureAggregator->Print(std::cout);

--- a/test/itkSatoVesselnessFeatureGeneratorTest1.cxx
+++ b/test/itkSatoVesselnessFeatureGeneratorTest1.cxx
@@ -51,7 +51,7 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using SatoVesselnessFeatureGeneratorType = itk::SatoVesselnessFeatureGenerator<Dimension>;
@@ -59,7 +59,7 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
 
   SatoVesselnessFeatureGeneratorType::Pointer featureGenerator = SatoVesselnessFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SatoVesselnessFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SatoVesselnessFeatureGenerator, FeatureGenerator);
 
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
@@ -79,7 +79,7 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double alpha1 = 0.5;
   if (argc > 4)
@@ -87,7 +87,7 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
     alpha1 = std::stod(argv[4]);
   }
   featureGenerator->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator->GetAlpha1());
 
   double alpha2 = 2.0;
   if (argc > 5)
@@ -95,10 +95,10 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
     alpha2 = std::stod(argv[5]);
   }
   featureGenerator->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator->GetAlpha2());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -113,7 +113,7 @@ itkSatoVesselnessFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetFileName(argv[2]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
@@ -45,7 +45,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using AggregatorType = itk::MinimumFeatureAggregator<Dimension>;
@@ -57,19 +57,19 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
 
   FeatureGeneratorType::Pointer featureGenerator1 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator1, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator1, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator2 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator2, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator2, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator3 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator3, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator3, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
 
   FeatureGeneratorType::Pointer featureGenerator4 = FeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator4, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator4, SatoVesselnessSigmoidFeatureGenerator, FeatureGenerator);
 
 
   double smallestSigma = 1.0;
@@ -78,16 +78,16 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     smallestSigma = std::stod(argv[3]);
   }
   featureGenerator1->SetSigma(smallestSigma);
-  TEST_SET_GET_VALUE(smallestSigma, featureGenerator1->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma, featureGenerator1->GetSigma());
   double smallestSigma2 = smallestSigma * 2.0;
   featureGenerator2->SetSigma(smallestSigma2);
-  TEST_SET_GET_VALUE(smallestSigma2, featureGenerator2->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma2, featureGenerator2->GetSigma());
   double smallestSigma3 = smallestSigma * 4.0;
   featureGenerator3->SetSigma(smallestSigma3);
-  TEST_SET_GET_VALUE(smallestSigma3, featureGenerator3->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma3, featureGenerator3->GetSigma());
   double smallestSigma4 = smallestSigma * 8.0;
   featureGenerator4->SetSigma(smallestSigma4);
-  TEST_SET_GET_VALUE(smallestSigma4, featureGenerator4->GetSigma());
+  ITK_TEST_SET_GET_VALUE(smallestSigma4, featureGenerator4->GetSigma());
 
   double alpha1 = 0.5;
   if (argc > 4)
@@ -95,13 +95,13 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     alpha1 = std::stod(argv[4]);
   }
   featureGenerator1->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator1->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator1->GetAlpha1());
   featureGenerator2->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator2->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator2->GetAlpha1());
   featureGenerator3->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator3->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator3->GetAlpha1());
   featureGenerator4->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator4->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator4->GetAlpha1());
 
   double alpha2 = 2.0;
   if (argc > 5)
@@ -109,13 +109,13 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     alpha2 = std::stod(argv[5]);
   }
   featureGenerator1->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
   featureGenerator2->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
   featureGenerator3->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
   featureGenerator4->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
 
   double sigmoidAlpha = -1.0;
   if (argc > 6)
@@ -123,13 +123,13 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     sigmoidAlpha = std::stod(argv[6]);
   }
   featureGenerator1->SetSigmoidAlpha(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetSigmoidAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetSigmoidAlpha());
   featureGenerator2->SetSigmoidAlpha(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetSigmoidAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetSigmoidAlpha());
   featureGenerator3->SetSigmoidAlpha(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetSigmoidAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetSigmoidAlpha());
   featureGenerator4->SetSigmoidAlpha(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetSigmoidAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetSigmoidAlpha());
 
   double sigmoidBeta = 90.0;
   if (argc > 7)
@@ -137,13 +137,13 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
     sigmoidBeta = std::stod(argv[7]);
   }
   featureGenerator1->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator1->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator1->GetSigmoidBeta());
   featureGenerator2->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator2->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator2->GetSigmoidBeta());
   featureGenerator3->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator3->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator3->GetSigmoidBeta());
   featureGenerator4->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator4->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator4->GetSigmoidBeta());
 
 
   using SpatialObjectType = AggregatorType::SpatialObjectType;
@@ -167,7 +167,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   featureAggregator->AddFeatureGenerator(featureGenerator3);
   featureAggregator->AddFeatureGenerator(featureGenerator4);
 
-  TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureAggregator->Update());
 
 
   SpatialObjectType::ConstPointer finalFeature = featureAggregator->GetFeature();
@@ -187,7 +187,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   featureAggregator->Print(std::cout);
 

--- a/test/itkSatoVesselnessSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkSatoVesselnessSigmoidFeatureGeneratorTest1.cxx
@@ -52,7 +52,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
 
   using SatoVesselnessSigmoidFeatureGeneratorType = itk::SatoVesselnessSigmoidFeatureGenerator<Dimension>;
@@ -61,7 +61,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
   SatoVesselnessSigmoidFeatureGeneratorType::Pointer featureGenerator =
     SatoVesselnessSigmoidFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     featureGenerator, SatoVesselnessSigmoidFeatureGenerator, SatoVesselnessFeatureGenerator);
 
 
@@ -82,7 +82,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     sigma = std::stod(argv[3]);
   }
   featureGenerator->SetSigma(sigma);
-  TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
+  ITK_TEST_SET_GET_VALUE(sigma, featureGenerator->GetSigma());
 
   double alpha1 = 0.5;
   if (argc > 4)
@@ -90,7 +90,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     alpha1 = std::stod(argv[4]);
   }
   featureGenerator->SetAlpha1(alpha1);
-  TEST_SET_GET_VALUE(alpha1, featureGenerator->GetAlpha1());
+  ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator->GetAlpha1());
 
   double alpha2 = 2.0;
   if (argc > 5)
@@ -98,7 +98,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     alpha2 = std::stod(argv[5]);
   }
   featureGenerator->SetAlpha2(alpha2);
-  TEST_SET_GET_VALUE(alpha2, featureGenerator->GetAlpha2());
+  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator->GetAlpha2());
 
   double sigmoidAlpha = 1.0;
   if (argc > 6)
@@ -106,7 +106,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     sigmoidAlpha = std::stod(argv[6]);
   }
   featureGenerator->SetSigmoidAlpha(sigmoidAlpha);
-  TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator->GetSigmoidAlpha());
+  ITK_TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator->GetSigmoidAlpha());
 
   double sigmoidBeta = -200.0;
   if (argc > 7)
@@ -114,10 +114,10 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     sigmoidBeta = std::stod(argv[7]);
   }
   featureGenerator->SetSigmoidBeta(sigmoidBeta);
-  TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator->GetSigmoidBeta());
+  ITK_TEST_SET_GET_VALUE(sigmoidBeta, featureGenerator->GetSigmoidBeta());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
@@ -133,7 +133,7 @@ itkSatoVesselnessSigmoidFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkSegmentationModuleTest1.cxx
+++ b/test/itkSegmentationModuleTest1.cxx
@@ -30,7 +30,7 @@ itkSegmentationModuleTest1(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule, SegmentationModule, ProcessObject);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule, SegmentationModule, ProcessObject);
 
 
   using ImageSpatialObjectType = itk::ImageSpatialObject<Dimension>;
@@ -43,7 +43,7 @@ itkSegmentationModuleTest1(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   segmentationModule->SetFeature(featureObject);
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkSegmentationVolumeEstimatorTest1.cxx
@@ -50,7 +50,7 @@ itkSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * itkNotUsed(argv
 
   VolumeEstimatorType::Pointer volumeEstimator = VolumeEstimatorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(volumeEstimator, VolumeEstimatorSurrogate, SegmentationVolumeEstimator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(volumeEstimator, VolumeEstimatorSurrogate, SegmentationVolumeEstimator);
 
   using ImageSpatialObjectType = itk::ImageSpatialObject<Dimension>;
 
@@ -58,7 +58,7 @@ itkSegmentationVolumeEstimatorTest1(int itkNotUsed(argc), char * itkNotUsed(argv
 
   volumeEstimator->SetInput(inputObject);
 
-  TRY_EXPECT_NO_EXCEPTION(volumeEstimator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(volumeEstimator->Update());
 
 
   VolumeEstimatorType::RealType volume1 = volumeEstimator->GetVolume();

--- a/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkShapeDetectionLevelSetSegmentationModuleTest1.cxx
@@ -42,7 +42,7 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     segmentationModule, ShapeDetectionLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
 
   using InputImageType = SegmentationModuleType::InputImageType;
@@ -62,7 +62,7 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
 
   inputReader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputReader->Update());
 
 
   RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
@@ -71,12 +71,12 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
   rescaler->SetOutputMinimum(-4.0);
   rescaler->SetOutputMaximum(4.0);
 
-  TRY_EXPECT_NO_EXCEPTION(rescaler->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(rescaler->Update());
 
 
   featureReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureReader->Update());
 
   using InputSpatialObjectType = SegmentationModuleType::InputSpatialObjectType;
   using FeatureSpatialObjectType = SegmentationModuleType::FeatureSpatialObjectType;
@@ -98,7 +98,7 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
     propagationScaling = std::stod(argv[4]);
   }
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   double curvatureScaling = 1.0;
   if (argc > 5)
@@ -106,7 +106,7 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
     curvatureScaling = std::stod(argv[5]);
   }
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   unsigned int maximumNumberOfIterations = 50;
   if (argc > 6)
@@ -114,10 +114,10 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
     maximumNumberOfIterations = std::stoi(argv[6]);
   }
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
   using SpatialObjectType = SegmentationModuleType::SpatialObjectType;
   SpatialObjectType::ConstPointer segmentation = segmentationModule->GetOutput();
@@ -132,7 +132,7 @@ itkShapeDetectionLevelSetSegmentationModuleTest1(int argc, char * argv[])
   writer->SetFileName(argv[3]);
   writer->SetInput(outputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkSigmoidFeatureGeneratorTest1.cxx
+++ b/test/itkSigmoidFeatureGeneratorTest1.cxx
@@ -51,14 +51,14 @@ itkSigmoidFeatureGeneratorTest1(int argc, char * argv[])
 
   reader->SetFileName(argv[1]);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   using SigmoidFeatureGeneratorType = itk::SigmoidFeatureGenerator<Dimension>;
   using SpatialObjectType = SigmoidFeatureGeneratorType::SpatialObjectType;
 
   SigmoidFeatureGeneratorType::Pointer featureGenerator = SigmoidFeatureGeneratorType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SigmoidFeatureGenerator, FeatureGenerator);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(featureGenerator, SigmoidFeatureGenerator, FeatureGenerator);
 
   InputImageSpatialObjectType::Pointer inputObject = InputImageSpatialObjectType::New();
 
@@ -76,7 +76,7 @@ itkSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     alpha = std::stod(argv[3]);
   }
   featureGenerator->SetAlpha(alpha);
-  TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
+  ITK_TEST_SET_GET_VALUE(alpha, featureGenerator->GetAlpha());
 
   double beta = 100.0;
   if (argc > 4)
@@ -84,10 +84,10 @@ itkSigmoidFeatureGeneratorTest1(int argc, char * argv[])
     beta = std::stod(argv[4]);
   }
   featureGenerator->SetBeta(beta);
-  TEST_SET_GET_VALUE(beta, featureGenerator->GetBeta());
+  ITK_TEST_SET_GET_VALUE(beta, featureGenerator->GetBeta());
 
 
-  TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(featureGenerator->Update());
 
   SpatialObjectType::ConstPointer feature = featureGenerator->GetFeature();
 
@@ -102,7 +102,7 @@ itkSigmoidFeatureGeneratorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;

--- a/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
+++ b/test/itkSinglePhaseLevelSetSegmentationModuleTest1.cxx
@@ -30,7 +30,7 @@ itkSinglePhaseLevelSetSegmentationModuleTest1(int itkNotUsed(argc), char * itkNo
 
   SegmentationModuleType::Pointer segmentationModule = SegmentationModuleType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(segmentationModule, SinglePhaseLevelSetSegmentationModule, SegmentationModule);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(segmentationModule, SinglePhaseLevelSetSegmentationModule, SegmentationModule);
 
   using ImageSpatialObjectType = itk::ImageSpatialObject<Dimension>;
 
@@ -44,26 +44,26 @@ itkSinglePhaseLevelSetSegmentationModuleTest1(int itkNotUsed(argc), char * itkNo
 
   constexpr double propagationScaling = 1.3;
   segmentationModule->SetPropagationScaling(propagationScaling);
-  TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
+  ITK_TEST_SET_GET_VALUE(propagationScaling, segmentationModule->GetPropagationScaling());
 
   constexpr double curvatureScaling = 1.7;
   segmentationModule->SetCurvatureScaling(curvatureScaling);
-  TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
+  ITK_TEST_SET_GET_VALUE(curvatureScaling, segmentationModule->GetCurvatureScaling());
 
   constexpr double advectionScaling = 1.9;
   segmentationModule->SetAdvectionScaling(advectionScaling);
-  TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
+  ITK_TEST_SET_GET_VALUE(advectionScaling, segmentationModule->GetAdvectionScaling());
 
   constexpr double maximumRMSError = 0.01;
   segmentationModule->SetMaximumRMSError(maximumRMSError);
-  TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
+  ITK_TEST_SET_GET_VALUE(maximumRMSError, segmentationModule->GetMaximumRMSError());
 
   constexpr unsigned int maximumNumberOfIterations = 179;
   segmentationModule->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, segmentationModule->GetMaximumNumberOfIterations());
 
 
-  TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(segmentationModule->Update());
 
 
   std::cout << "Test finished." << std::endl;

--- a/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
+++ b/test/itkVotingBinaryHoleFillFloodingImageFilterTest1.cxx
@@ -71,7 +71,7 @@ itkVotingBinaryHoleFillFloodingImageFilterTest1(int argc, char * argv[])
 
   FilterType::Pointer filter = FilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(filter, VotingBinaryHoleFillFloodingImageFilter, VotingBinaryImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, VotingBinaryHoleFillFloodingImageFilter, VotingBinaryImageFilter);
 
 
   const unsigned int radius = std::stoi(argv[4]);
@@ -93,13 +93,13 @@ itkVotingBinaryHoleFillFloodingImageFilterTest1(int argc, char * argv[])
 
   const unsigned int maximumNumberOfIterations = std::stoi(argv[6]);
   filter->SetMaximumNumberOfIterations(maximumNumberOfIterations);
-  TEST_SET_GET_VALUE(maximumNumberOfIterations, filter->GetMaximumNumberOfIterations());
+  ITK_TEST_SET_GET_VALUE(maximumNumberOfIterations, filter->GetMaximumNumberOfIterations());
 
   thresholder->SetInput(reader->GetOutput());
   filter->SetInput(thresholder->GetOutput());
   writer->SetInput(filter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   std::cout << "Iteration used = " << filter->GetCurrentIterationNumber() << std::endl;

--- a/test/itkWeightedSumFeatureAggregatorTest1.cxx
+++ b/test/itkWeightedSumFeatureAggregatorTest1.cxx
@@ -47,7 +47,7 @@ itkWeightedSumFeatureAggregatorTest1(int argc, char * argv[])
 
   inputImageReader->SetFileName(argv[2]);
 
-  TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(inputImageReader->Update());
 
 
   using AggregatorType = itk::WeightedSumFeatureAggregator<Dimension>;
@@ -117,7 +117,7 @@ itkWeightedSumFeatureAggregatorTest1(int argc, char * argv[])
   writer->SetInput(outputImage);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 
   featureAggregator->Print(std::cout);
@@ -127,7 +127,7 @@ itkWeightedSumFeatureAggregatorTest1(int argc, char * argv[])
   //
   featureAggregator->AddWeight(13.0);
 
-  TRY_EXPECT_EXCEPTION(featureAggregator->Update());
+  ITK_TRY_EXPECT_EXCEPTION(featureAggregator->Update());
 
 
   std::cout << "Test finished." << std::endl;


### PR DESCRIPTION
All of the testing macros used in this module do not contain the new testing macro definitions. The only changes this entails is placing an `ITK_` in front of the existing macros. This will help generate a clean build with the current ITK `master`.