### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/Examples/LesionSegmentation.cxx
+++ b/Examples/LesionSegmentation.cxx
@@ -463,7 +463,7 @@ main(int argc, char * argv[])
   InputImageType::SizeType roiSize;
   for (unsigned int i = 0; i < ImageDimension; i++)
   {
-    roiSize[i] = abs(pi2[i] - pi1[i]);
+    roiSize[i] = itk::Math::abs(pi2[i] - pi1[i]);
     startIndex[i] = (pi1[i] < pi2[i]) ? pi1[i] : pi2[i];
   }
   InputImageType::RegionType roiRegion(startIndex, roiSize);

--- a/Examples/itkLesionSegmentationCommandLineProgressReporter.cxx
+++ b/Examples/itkLesionSegmentationCommandLineProgressReporter.cxx
@@ -62,7 +62,7 @@ LesionSegmentationCommandLineProgressReporter ::ExecuteInternal(const Object * c
       {
         this->ProgressString = statusText;
       }
-      if (fabs((double)(progressValue - this->ProgressValue)) >= 1.0)
+      if (itk::Math::abs((double)(progressValue - this->ProgressValue)) >= 1.0)
       {
         this->ProgressValue = static_cast<int>(filter->GetProgress() * 100.0);
         report = true;

--- a/include/itkBinaryThresholdFeatureGenerator.hxx
+++ b/include/itkBinaryThresholdFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBinaryThresholdFeatureGenerator_hxx
 #define itkBinaryThresholdFeatureGenerator_hxx
 
-#include "itkBinaryThresholdFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkCannyEdgeDetectionRecursiveGaussianImageFilter_hxx
 #define itkCannyEdgeDetectionRecursiveGaussianImageFilter_hxx
-#include "itkCannyEdgeDetectionRecursiveGaussianImageFilter.h"
 
 #include "itkZeroCrossingImageFilter.h"
 #include "itkNeighborhoodInnerProduct.h"

--- a/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.hxx
+++ b/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCannyEdgesDistanceAdvectionFieldFeatureGenerator_hxx
 #define itkCannyEdgesDistanceAdvectionFieldFeatureGenerator_hxx
 
-#include "itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkCannyEdgesDistanceFeatureGenerator.hxx
+++ b/include/itkCannyEdgesDistanceFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCannyEdgesDistanceFeatureGenerator_hxx
 #define itkCannyEdgesDistanceFeatureGenerator_hxx
 
-#include "itkCannyEdgesDistanceFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkCannyEdgesFeatureGenerator.hxx
+++ b/include/itkCannyEdgesFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkCannyEdgesFeatureGenerator_hxx
 #define itkCannyEdgesFeatureGenerator_hxx
 
-#include "itkCannyEdgesFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkConfidenceConnectedSegmentationModule.hxx
+++ b/include/itkConfidenceConnectedSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkConfidenceConnectedSegmentationModule_hxx
 #define itkConfidenceConnectedSegmentationModule_hxx
 
-#include "itkConfidenceConnectedSegmentationModule.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkConnectedThresholdSegmentationModule.hxx
+++ b/include/itkConnectedThresholdSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkConnectedThresholdSegmentationModule_hxx
 #define itkConnectedThresholdSegmentationModule_hxx
 
-#include "itkConnectedThresholdSegmentationModule.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkDescoteauxSheetnessFeatureGenerator.hxx
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkDescoteauxSheetnessFeatureGenerator_hxx
 #define itkDescoteauxSheetnessFeatureGenerator_hxx
 
-#include "itkDescoteauxSheetnessFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.hxx
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule_hxx
 #define itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule_hxx
 
-#include "itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h"
 #include "itkGeodesicActiveContourLevelSetImageFilter.h"
 #include "itkProgressAccumulator.h"
 

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.hxx
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFastMarchingAndShapeDetectionLevelSetSegmentationModule_hxx
 #define itkFastMarchingAndShapeDetectionLevelSetSegmentationModule_hxx
 
-#include "itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h"
 #include "itkShapeDetectionLevelSetImageFilter.h"
 #include "itkProgressAccumulator.h"
 

--- a/include/itkFastMarchingSegmentationModule.hxx
+++ b/include/itkFastMarchingSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFastMarchingSegmentationModule_hxx
 #define itkFastMarchingSegmentationModule_hxx
 
-#include "itkFastMarchingSegmentationModule.h"
 #include "itkImageRegionIterator.h"
 #include "itkFastMarchingImageFilter.h"
 #include "itkIntensityWindowingImageFilter.h"

--- a/include/itkFeatureAggregator.hxx
+++ b/include/itkFeatureAggregator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFeatureAggregator_hxx
 #define itkFeatureAggregator_hxx
 
-#include "itkFeatureAggregator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkFeatureGenerator.hxx
+++ b/include/itkFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFeatureGenerator_hxx
 #define itkFeatureGenerator_hxx
 
-#include "itkFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkFrangiTubularnessFeatureGenerator.hxx
+++ b/include/itkFrangiTubularnessFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrangiTubularnessFeatureGenerator_hxx
 #define itkFrangiTubularnessFeatureGenerator_hxx
 
-#include "itkFrangiTubularnessFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.hxx
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkGeodesicActiveContourLevelSetSegmentationModule_hxx
 #define itkGeodesicActiveContourLevelSetSegmentationModule_hxx
 
-#include "itkGeodesicActiveContourLevelSetSegmentationModule.h"
 #include "itkGeodesicActiveContourLevelSetImageFilter.h"
 #include "itkProgressAccumulator.h"
 

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.hxx
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkGradientMagnitudeSigmoidFeatureGenerator_hxx
 #define itkGradientMagnitudeSigmoidFeatureGenerator_hxx
 
-#include "itkGradientMagnitudeSigmoidFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.hxx
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkGrayscaleImageSegmentationVolumeEstimator_hxx
 #define itkGrayscaleImageSegmentationVolumeEstimator_hxx
 
-#include "itkGrayscaleImageSegmentationVolumeEstimator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkIsotropicResampler.hxx
+++ b/include/itkIsotropicResampler.hxx
@@ -18,7 +18,6 @@
 #ifndef itkIsotropicResampler_hxx
 #define itkIsotropicResampler_hxx
 
-#include "itkIsotropicResampler.h"
 #include "itkResampleImageFilter.h"
 #include "itkIdentityTransform.h"
 #include "itkBSplineInterpolateImageFunction.h"

--- a/include/itkIsotropicResamplerImageFilter.hxx
+++ b/include/itkIsotropicResamplerImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkIsotropicResamplerImageFilter_hxx
 #define itkIsotropicResamplerImageFilter_hxx
 
-#include "itkIsotropicResamplerImageFilter.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkLandmarksReader.hxx
+++ b/include/itkLandmarksReader.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLandmarksReader_hxx
 #define itkLandmarksReader_hxx
 
-#include "itkLandmarksReader.h"
 #include "itkSpatialObjectReader.h"
 
 

--- a/include/itkLesionSegmentationImageFilter8.hxx
+++ b/include/itkLesionSegmentationImageFilter8.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkLesionSegmentationImageFilter8_hxx
 #define itkLesionSegmentationImageFilter8_hxx
-#include "itkLesionSegmentationImageFilter8.h"
 
 #include "itkNumericTraits.h"
 #include "itkProgressReporter.h"

--- a/include/itkLesionSegmentationMethod.hxx
+++ b/include/itkLesionSegmentationMethod.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLesionSegmentationMethod_hxx
 #define itkLesionSegmentationMethod_hxx
 
-#include "itkLesionSegmentationMethod.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkLungWallFeatureGenerator.hxx
+++ b/include/itkLungWallFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLungWallFeatureGenerator_hxx
 #define itkLungWallFeatureGenerator_hxx
 
-#include "itkLungWallFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkMaximumFeatureAggregator.hxx
+++ b/include/itkMaximumFeatureAggregator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMaximumFeatureAggregator_hxx
 #define itkMaximumFeatureAggregator_hxx
 
-#include "itkMaximumFeatureAggregator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageFileWriter.h"

--- a/include/itkMinimumFeatureAggregator.hxx
+++ b/include/itkMinimumFeatureAggregator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMinimumFeatureAggregator_hxx
 #define itkMinimumFeatureAggregator_hxx
 
-#include "itkMinimumFeatureAggregator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageFileWriter.h"

--- a/include/itkMorphologicalOpeningFeatureGenerator.hxx
+++ b/include/itkMorphologicalOpeningFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMorphologicalOpeningFeatureGenerator_hxx
 #define itkMorphologicalOpeningFeatureGenerator_hxx
 
-#include "itkMorphologicalOpeningFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkMorphologicalOpenningFeatureGenerator.hxx
+++ b/include/itkMorphologicalOpenningFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMorphologicalOpenningFeatureGenerator_hxx
 #define itkMorphologicalOpenningFeatureGenerator_hxx
 
-#include "itkMorphologicalOpenningFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkRegionCompetitionImageFilter.hxx
+++ b/include/itkRegionCompetitionImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkRegionCompetitionImageFilter_hxx
 #define itkRegionCompetitionImageFilter_hxx
 
-#include "itkRegionCompetitionImageFilter.h"
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionExclusionIteratorWithIndex.h"

--- a/include/itkRegionGrowingSegmentationModule.hxx
+++ b/include/itkRegionGrowingSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkRegionGrowingSegmentationModule_hxx
 #define itkRegionGrowingSegmentationModule_hxx
 
-#include "itkRegionGrowingSegmentationModule.h"
 #include "itkImageRegionIterator.h"
 
 

--- a/include/itkSatoLocalStructureFeatureGenerator.hxx
+++ b/include/itkSatoLocalStructureFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSatoLocalStructureFeatureGenerator_hxx
 #define itkSatoLocalStructureFeatureGenerator_hxx
 
-#include "itkSatoLocalStructureFeatureGenerator.h"
 
 
 namespace itk

--- a/include/itkSatoVesselnessFeatureGenerator.hxx
+++ b/include/itkSatoVesselnessFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSatoVesselnessFeatureGenerator_hxx
 #define itkSatoVesselnessFeatureGenerator_hxx
 
-#include "itkSatoVesselnessFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.hxx
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSatoVesselnessSigmoidFeatureGenerator_hxx
 #define itkSatoVesselnessSigmoidFeatureGenerator_hxx
 
-#include "itkSatoVesselnessSigmoidFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 

--- a/include/itkSegmentationModule.hxx
+++ b/include/itkSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSegmentationModule_hxx
 #define itkSegmentationModule_hxx
 
-#include "itkSegmentationModule.h"
 
 
 namespace itk

--- a/include/itkSegmentationVolumeEstimator.hxx
+++ b/include/itkSegmentationVolumeEstimator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSegmentationVolumeEstimator_hxx
 #define itkSegmentationVolumeEstimator_hxx
 
-#include "itkSegmentationVolumeEstimator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkShapeDetectionLevelSetSegmentationModule.hxx
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkShapeDetectionLevelSetSegmentationModule_hxx
 #define itkShapeDetectionLevelSetSegmentationModule_hxx
 
-#include "itkShapeDetectionLevelSetSegmentationModule.h"
 #include "itkShapeDetectionLevelSetImageFilter.h"
 
 

--- a/include/itkSigmoidFeatureGenerator.hxx
+++ b/include/itkSigmoidFeatureGenerator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSigmoidFeatureGenerator_hxx
 #define itkSigmoidFeatureGenerator_hxx
 
-#include "itkSigmoidFeatureGenerator.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkSinglePhaseLevelSetSegmentationModule.hxx
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSinglePhaseLevelSetSegmentationModule_hxx
 #define itkSinglePhaseLevelSetSegmentationModule_hxx
 
-#include "itkSinglePhaseLevelSetSegmentationModule.h"
 #include "itkLandmarkSpatialObject.h"
 #include "itkIntensityWindowingImageFilter.h"
 

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
@@ -518,11 +518,11 @@ VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>::MaxVesselResponse(
       ev[1] = ES.get_eigenvalue(1);
       ev[2] = ES.get_eigenvalue(2);
 
-      if (std::abs(ev[0]) > std::abs(ev[1]))
+      if (itk::Math::abs(ev[0]) > itk::Math::abs(ev[1]))
         std::swap(ev[0], ev[1]);
-      if (std::abs(ev[1]) > std::abs(ev[2]))
+      if (itk::Math::abs(ev[1]) > itk::Math::abs(ev[2]))
         std::swap(ev[1], ev[2]);
-      if (std::abs(ev[0]) > std::abs(ev[1]))
+      if (itk::Math::abs(ev[0]) > itk::Math::abs(ev[1]))
         std::swap(ev[0], ev[1]);
 
       const Precision vesselness = VesselnessFunction3D(ev[0], ev[1], ev[2]);
@@ -564,9 +564,9 @@ VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>::VesselnessFunction
     const Precision vc2 = 2.0 * m_Gamma * m_Gamma;
 
     const Precision Ra2 = (l2 * l2) / (l3 * l3);
-    const Precision Rb2 = (l1 * l1) / std::abs(l2 * l3);
+    const Precision Rb2 = (l1 * l1) / itk::Math::abs(l2 * l3);
     const Precision S2 = (l1 * l1) + (l2 * l2) + (l3 * l3);
-    const Precision T = std::exp(-(2 * smoothC * smoothC) / (std::abs(l2) * l3 * l3));
+    const Precision T = std::exp(-(2 * smoothC * smoothC) / (itk::Math::abs(l2) * l3 * l3));
 
     vesselness = T * (1.0 - std::exp(-Ra2 / va2)) * std::exp(-Rb2 / vb2) * (1.0 - std::exp(-S2 / vc2));
   }
@@ -610,11 +610,11 @@ VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>::DiffusionTensor()
     ev[1] = ES.get_eigenvalue(1);
     ev[2] = ES.get_eigenvalue(2);
 
-    if (std::abs(ev[0]) > std::abs(ev[1]))
+    if (itk::Math::abs(ev[0]) > itk::Math::abs(ev[1]))
       std::swap(ev[0], ev[1]);
-    if (std::abs(ev[1]) > std::abs(ev[2]))
+    if (itk::Math::abs(ev[1]) > itk::Math::abs(ev[2]))
       std::swap(ev[1], ev[2]);
-    if (std::abs(ev[0]) > std::abs(ev[1]))
+    if (itk::Math::abs(ev[0]) > itk::Math::abs(ev[1]))
       std::swap(ev[0], ev[1]);
 
     const Precision       V = VesselnessFunction3D(ev[0], ev[1], ev[2]);

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkVesselEnhancingDiffusion3DImageFilter_hxx
 #define itkVesselEnhancingDiffusion3DImageFilter_hxx
 
-#include "itkVesselEnhancingDiffusion3DImageFilter.h"
 
 #include "itkCastImageFilter.h"
 #include "itkConstShapedNeighborhoodIterator.h"

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkVotingBinaryHoleFillFloodingImageFilter_hxx
 #define itkVotingBinaryHoleFillFloodingImageFilter_hxx
 
-#include "itkVotingBinaryHoleFillFloodingImageFilter.h"
 #include "itkConstNeighborhoodIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionExclusionIteratorWithIndex.h"

--- a/include/itkWeightedSumFeatureAggregator.hxx
+++ b/include/itkWeightedSumFeatureAggregator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkWeightedSumFeatureAggregator_hxx
 #define itkWeightedSumFeatureAggregator_hxx
 
-#include "itkWeightedSumFeatureAggregator.h"
 #include "itkImageSpatialObject.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageFileWriter.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

