### PR TITLE
COMP: ISO C++17 does not allow dynamic exception

### DIFF
--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -198,7 +198,7 @@ public:
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */
   void
-  GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
+  GenerateInputRequestedRegion() noexcept(false) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -95,8 +95,8 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>::Alloc
 
 template <typename TInputImage, typename TOutputImage>
 void
-CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() throw(
-  InvalidRequestedRegionError)
+CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion() noexcept(
+  false)
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/include/itkConfidenceConnectedSegmentationModule.hxx
+++ b/include/itkConfidenceConnectedSegmentationModule.hxx
@@ -74,11 +74,9 @@ ConfidenceConnectedSegmentationModule<NDimension>::GenerateData()
 
   const LandmarkPointListType & points = inputSeeds->GetPoints();
 
-  IndexType index;
-
   for (unsigned int i = 0; i < numberOfPoints; i++)
   {
-    featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace(), index);
+    const IndexType index = featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace());
     filter->AddSeed(index);
   }
 

--- a/include/itkConnectedThresholdSegmentationModule.hxx
+++ b/include/itkConnectedThresholdSegmentationModule.hxx
@@ -74,11 +74,9 @@ ConnectedThresholdSegmentationModule<NDimension>::GenerateData()
 
   const LandmarkPointListType & points = inputSeeds->GetPoints();
 
-  IndexType index;
-
   for (unsigned int i = 0; i < numberOfPoints; i++)
   {
-    featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace(), index);
+    const IndexType index = featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace());
     filter->AddSeed(index);
   }
 

--- a/include/itkFastMarchingSegmentationModule.hxx
+++ b/include/itkFastMarchingSegmentationModule.hxx
@@ -101,11 +101,10 @@ FastMarchingSegmentationModule<NDimension>::GenerateData()
 
   const LandmarkPointListType & points = inputSeeds->GetPoints();
 
-  IndexType index;
 
   for (unsigned int i = 0; i < numberOfPoints; i++)
   {
-    featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace(), index);
+    const IndexType index = featureImage->TransformPhysicalPointToIndex(points[i].GetPositionInObjectSpace());
 
     NodeType node;
 

--- a/include/itkLesionSegmentationImageFilter8.h
+++ b/include/itkLesionSegmentationImageFilter8.h
@@ -83,7 +83,7 @@ public:
   using SigmaArrayType = typename CannyEdgesFeatureGeneratorType::SigmaArrayType;
 
   void
-  GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
+  GenerateInputRequestedRegion() noexcept(false) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/include/itkLesionSegmentationImageFilter8.hxx
+++ b/include/itkLesionSegmentationImageFilter8.hxx
@@ -92,8 +92,7 @@ LesionSegmentationImageFilter8<TInputImage, TOutputImage>::LesionSegmentationIma
 
 template <typename TInputImage, typename TOutputImage>
 void
-LesionSegmentationImageFilter8<TInputImage, TOutputImage>::GenerateInputRequestedRegion() throw(
-  InvalidRequestedRegionError)
+LesionSegmentationImageFilter8<TInputImage, TOutputImage>::GenerateInputRequestedRegion() noexcept(false)
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -8,6 +8,10 @@ file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 # By convention those modules outside of ITK are not prefixed with
 # ITK.
 
+if(LSTK_USE_VTK)
+  set(LesionSizingToolkit_VTK_GLUE_SUPPORT ITKVtkGlue)
+endif()
+
 # define the dependencies of the include module and the tests
 itk_module(LesionSizingToolkit
   DEPENDS
@@ -17,7 +21,7 @@ itk_module(LesionSizingToolkit
     ITKRegionGrowing
     ITKLabelVoting
     ITKMathematicalMorphology
-    ITKVtkGlue
+    ${LesionSizingToolkit_VTK_GLUE_SUPPORT}
     ITKIOSpatialObjects
     ITKCommon
     ITKIOGDCM

--- a/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
+++ b/src/itkImageReadRegionOfInterestAroundSeedWrite.cxx
@@ -114,9 +114,7 @@ main(int argc, char ** argv)
 
   const InputImageType * inputImage = reader->GetOutput();
 
-  InputImageType::IndexType centralIndex;
-
-  inputImage->TransformPhysicalPointToIndex(seedPoint, centralIndex);
+  InputImageType::IndexType centralIndex = inputImage->TransformPhysicalPointToIndex(seedPoint);
 
   InputImageType::SpacingType spacing = inputImage->GetSpacing();
 

--- a/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
+++ b/test/itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1.cxx
@@ -102,35 +102,36 @@ itkSatoVesselnessSigmoidFeatureGeneratorMultiScaleTest1(int argc, char * argv[])
   ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator3->GetAlpha1());
   featureGenerator4->SetAlpha1(alpha1);
   ITK_TEST_SET_GET_VALUE(alpha1, featureGenerator4->GetAlpha1());
-
-  double alpha2 = 2.0;
-  if (argc > 5)
   {
-    alpha2 = std::stod(argv[5]);
+    double alpha2 = 2.0;
+    if (argc > 5)
+    {
+      alpha2 = std::stod(argv[5]);
+    }
+    featureGenerator1->SetAlpha2(alpha2);
+    ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
+    featureGenerator2->SetAlpha2(alpha2);
+    ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
+    featureGenerator3->SetAlpha2(alpha2);
+    ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
+    featureGenerator4->SetAlpha2(alpha2);
+    ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
   }
-  featureGenerator1->SetAlpha2(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetAlpha2());
-  featureGenerator2->SetAlpha2(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetAlpha2());
-  featureGenerator3->SetAlpha2(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetAlpha2());
-  featureGenerator4->SetAlpha2(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetAlpha2());
-
-  double sigmoidAlpha = -1.0;
-  if (argc > 6)
   {
-    sigmoidAlpha = std::stod(argv[6]);
+    double sigmoidAlpha = -1.0;
+    if (argc > 6)
+    {
+      sigmoidAlpha = std::stod(argv[6]);
+    }
+    featureGenerator1->SetSigmoidAlpha(sigmoidAlpha);
+    ITK_TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator1->GetSigmoidAlpha());
+    featureGenerator2->SetSigmoidAlpha(sigmoidAlpha);
+    ITK_TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator2->GetSigmoidAlpha());
+    featureGenerator3->SetSigmoidAlpha(sigmoidAlpha);
+    ITK_TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator3->GetSigmoidAlpha());
+    featureGenerator4->SetSigmoidAlpha(sigmoidAlpha);
+    ITK_TEST_SET_GET_VALUE(sigmoidAlpha, featureGenerator4->GetSigmoidAlpha());
   }
-  featureGenerator1->SetSigmoidAlpha(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator1->GetSigmoidAlpha());
-  featureGenerator2->SetSigmoidAlpha(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator2->GetSigmoidAlpha());
-  featureGenerator3->SetSigmoidAlpha(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator3->GetSigmoidAlpha());
-  featureGenerator4->SetSigmoidAlpha(alpha2);
-  ITK_TEST_SET_GET_VALUE(alpha2, featureGenerator4->GetSigmoidAlpha());
-
   double sigmoidBeta = 90.0;
   if (argc > 7)
   {


### PR DESCRIPTION
LesionSizingToolkit/src/itkCannyEdgeDetectionImageFilter2.cxx:30: LesionSizingToolkit/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h:201:34: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
  201 |   GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
LesionSizingToolkit/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h:201:34: note: use 'noexcept(false)' instead
  201 |   GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                  noexcept(false)