### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/Examples/itkLesionSegmentationCommandLineProgressReporter.h
+++ b/Examples/itkLesionSegmentationCommandLineProgressReporter.h
@@ -38,7 +38,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LesionSegmentationCommandLineProgressReporter, Command);
+  itkOverrideGetNameOfClassMacro(LesionSegmentationCommandLineProgressReporter);
 
   // Description:
   // Satisfy the superclass API for callbacks. Recall that the caller is

--- a/include/itkBinaryThresholdFeatureGenerator.h
+++ b/include/itkBinaryThresholdFeatureGenerator.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(BinaryThresholdFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(BinaryThresholdFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -137,7 +137,7 @@ public:
   using OutputImageRegionType = typename TOutputImage::RegionType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CannyEdgeDetectionRecursiveGaussianImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(CannyEdgeDetectionRecursiveGaussianImageFilter);
 
   /** ImageDimension constant    */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CannyEdgesDistanceAdvectionFieldFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(CannyEdgesDistanceAdvectionFieldFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkCannyEdgesDistanceFeatureGenerator.h
+++ b/include/itkCannyEdgesDistanceFeatureGenerator.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CannyEdgesDistanceFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(CannyEdgesDistanceFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkCannyEdgesFeatureGenerator.h
+++ b/include/itkCannyEdgesFeatureGenerator.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CannyEdgesFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(CannyEdgesFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkConfidenceConnectedSegmentationModule.h
+++ b/include/itkConfidenceConnectedSegmentationModule.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ConfidenceConnectedSegmentationModule, RegionGrowingSegmentationModule);
+  itkOverrideGetNameOfClassMacro(ConfidenceConnectedSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkConnectedThresholdSegmentationModule.h
+++ b/include/itkConnectedThresholdSegmentationModule.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ConnectedThresholdSegmentationModule, RegionGrowingSegmentationModule);
+  itkOverrideGetNameOfClassMacro(ConnectedThresholdSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkDescoteauxSheetnessFeatureGenerator.h
+++ b/include/itkDescoteauxSheetnessFeatureGenerator.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(DescoteauxSheetnessFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(DescoteauxSheetnessFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkDescoteauxSheetnessImageFilter.h
+++ b/include/itkDescoteauxSheetnessImageFilter.h
@@ -203,7 +203,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(DescoteauxSheetnessImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(DescoteauxSheetnessImageFilter);
 
   /** Set the normalization term for sheetness */
   void

--- a/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
+  itkOverrideGetNameOfClassMacro(FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkFastMarchingAndShapeDetectionLevelSetSegmentationModule.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FastMarchingAndShapeDetectionLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
+  itkOverrideGetNameOfClassMacro(FastMarchingAndShapeDetectionLevelSetSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFastMarchingSegmentationModule.h
+++ b/include/itkFastMarchingSegmentationModule.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FastMarchingSegmentationModule, SinglePhaseLevelSetSegmentationModule);
+  itkOverrideGetNameOfClassMacro(FastMarchingSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFeatureAggregator.h
+++ b/include/itkFeatureAggregator.h
@@ -52,7 +52,7 @@ public:
   /** This is an abstract class, therefore it doesn't need the itkNewMacro() */
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FeatureAggregator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(FeatureAggregator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFeatureGenerator.h
+++ b/include/itkFeatureGenerator.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FeatureGenerator, ProcessObject);
+  itkOverrideGetNameOfClassMacro(FeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFrangiTubularnessFeatureGenerator.h
+++ b/include/itkFrangiTubularnessFeatureGenerator.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrangiTubularnessFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(FrangiTubularnessFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkFrangiTubularnessImageFilter.h
+++ b/include/itkFrangiTubularnessImageFilter.h
@@ -211,7 +211,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FrangiTubularnessImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(FrangiTubularnessImageFilter);
 
   /** Set the normalization term for sheetness */
   void

--- a/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/include/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GeodesicActiveContourLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
+  itkOverrideGetNameOfClassMacro(GeodesicActiveContourLevelSetSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
+++ b/include/itkGradientMagnitudeSigmoidFeatureGenerator.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GradientMagnitudeSigmoidFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(GradientMagnitudeSigmoidFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkGrayscaleImageSegmentationVolumeEstimator.h
+++ b/include/itkGrayscaleImageSegmentationVolumeEstimator.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GrayscaleImageSegmentationVolumeEstimator, SegmentationVolumeEstimator);
+  itkOverrideGetNameOfClassMacro(GrayscaleImageSegmentationVolumeEstimator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkIsotropicResampler.h
+++ b/include/itkIsotropicResampler.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IsotropicResampler, ProcessObject);
+  itkOverrideGetNameOfClassMacro(IsotropicResampler);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkIsotropicResamplerImageFilter.h
+++ b/include/itkIsotropicResamplerImageFilter.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IsotropicResamplerImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(IsotropicResamplerImageFilter);
 
   /** ImageDimension constant    */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkLandmarksReader.h
+++ b/include/itkLandmarksReader.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LandmarksReader, ProcessObject);
+  itkOverrideGetNameOfClassMacro(LandmarksReader);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkLesionSegmentationImageFilter8.h
+++ b/include/itkLesionSegmentationImageFilter8.h
@@ -72,7 +72,7 @@ public:
   using RegionType = typename TOutputImage::RegionType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LesionSegmentationImageFilter8, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LesionSegmentationImageFilter8);
 
   /** ImageDimension constant    */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkLesionSegmentationMethod.h
+++ b/include/itkLesionSegmentationMethod.h
@@ -56,7 +56,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LesionSegmentationMethod, ProcessObject);
+  itkOverrideGetNameOfClassMacro(LesionSegmentationMethod);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkLocalStructureImageFilter.h
+++ b/include/itkLocalStructureImageFilter.h
@@ -193,7 +193,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(LocalStructureImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(LocalStructureImageFilter);
 
   /** Set the normalization term for sheetness */
   void

--- a/include/itkLungWallFeatureGenerator.h
+++ b/include/itkLungWallFeatureGenerator.h
@@ -56,7 +56,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LungWallFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(LungWallFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkMaximumFeatureAggregator.h
+++ b/include/itkMaximumFeatureAggregator.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MaximumFeatureAggregator, FeatureAggregator);
+  itkOverrideGetNameOfClassMacro(MaximumFeatureAggregator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkMinimumFeatureAggregator.h
+++ b/include/itkMinimumFeatureAggregator.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MinimumFeatureAggregator, FeatureAggregator);
+  itkOverrideGetNameOfClassMacro(MinimumFeatureAggregator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkMorphologicalOpeningFeatureGenerator.h
+++ b/include/itkMorphologicalOpeningFeatureGenerator.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MorphologicalOpeningFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(MorphologicalOpeningFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkMorphologicalOpenningFeatureGenerator.h
+++ b/include/itkMorphologicalOpenningFeatureGenerator.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MorphologicalOpenningFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(MorphologicalOpenningFeatureGenerator);
 
   /** Dimension of the space */
   itkStaticConstMacro(Dimension, unsigned int, NDimension);

--- a/include/itkRegionCompetitionImageFilter.h
+++ b/include/itkRegionCompetitionImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods).  */
-  itkTypeMacro(RegionCompetitionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(RegionCompetitionImageFilter);
 
   using InputImageType = TInputImage;
   using InputImagePointer = typename InputImageType::Pointer;

--- a/include/itkRegionGrowingSegmentationModule.h
+++ b/include/itkRegionGrowingSegmentationModule.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RegionGrowingSegmentationModule, SegmentationModule);
+  itkOverrideGetNameOfClassMacro(RegionGrowingSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSatoLocalStructureFeatureGenerator.h
+++ b/include/itkSatoLocalStructureFeatureGenerator.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SatoLocalStructureFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(SatoLocalStructureFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSatoVesselnessFeatureGenerator.h
+++ b/include/itkSatoVesselnessFeatureGenerator.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SatoVesselnessFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(SatoVesselnessFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSatoVesselnessSigmoidFeatureGenerator.h
+++ b/include/itkSatoVesselnessSigmoidFeatureGenerator.h
@@ -52,7 +52,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SatoVesselnessSigmoidFeatureGenerator, SatoVesselnessFeatureGenerator);
+  itkOverrideGetNameOfClassMacro(SatoVesselnessSigmoidFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSegmentationModule.h
+++ b/include/itkSegmentationModule.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SegmentationModule, ProcessObject);
+  itkOverrideGetNameOfClassMacro(SegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSegmentationVolumeEstimator.h
+++ b/include/itkSegmentationVolumeEstimator.h
@@ -50,7 +50,7 @@ public:
   /** This is an abstract class, therefore it doesn't need the itkNewMacro() */
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SegmentationVolumeEstimator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(SegmentationVolumeEstimator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkShapeDetectionLevelSetSegmentationModule.h
+++ b/include/itkShapeDetectionLevelSetSegmentationModule.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ShapeDetectionLevelSetSegmentationModule, SinglePhaseLevelSetSegmentationModule);
+  itkOverrideGetNameOfClassMacro(ShapeDetectionLevelSetSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSigmoidFeatureGenerator.h
+++ b/include/itkSigmoidFeatureGenerator.h
@@ -56,7 +56,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SigmoidFeatureGenerator, FeatureGenerator);
+  itkOverrideGetNameOfClassMacro(SigmoidFeatureGenerator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/include/itkSinglePhaseLevelSetSegmentationModule.h
@@ -48,7 +48,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SinglePhaseLevelSetSegmentationModule, SegmentationModule);
+  itkOverrideGetNameOfClassMacro(SinglePhaseLevelSetSegmentationModule);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/include/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/include/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -89,7 +89,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   itkNewMacro(Self);
-  itkTypeMacro(VesselEnhancingDiffusion3DImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(VesselEnhancingDiffusion3DImageFilter);
 
   itkSetMacro(TimeStep, Precision);
   itkSetMacro(Iterations, unsigned int);

--- a/include/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/include/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods).  */
-  itkTypeMacro(VotingBinaryHoleFillFloodingImageFilter, VotingBinaryImageFilter);
+  itkOverrideGetNameOfClassMacro(VotingBinaryHoleFillFloodingImageFilter);
 
   using InputImageType = typename Superclass::InputImageType;
   using InputImagePointer = typename InputImageType::Pointer;

--- a/include/itkWeightedSumFeatureAggregator.h
+++ b/include/itkWeightedSumFeatureAggregator.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(WeightedSumFeatureAggregator, FeatureAggregator);
+  itkOverrideGetNameOfClassMacro(WeightedSumFeatureAggregator);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/test/itkFeatureAggregatorTest1.cxx
+++ b/test/itkFeatureAggregatorTest1.cxx
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FeatureAggregatorSurrogate, FeatureAggregator);
+  itkOverrideGetNameOfClassMacro(FeatureAggregatorSurrogate);
 
   /** Dimension of the space */
   static constexpr unsigned int Dimension = NDimension;

--- a/test/itkMaximumFeatureAggregatorTest2.cxx
+++ b/test/itkMaximumFeatureAggregatorTest2.cxx
@@ -39,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MaximumFeatureAggregatorSurrogage, MaximumFeatureAggregator);
+  itkOverrideGetNameOfClassMacro(MaximumFeatureAggregatorSurrogage);
 
   using InputFeatureType = Superclass::InputFeatureType;
 

--- a/test/itkMinimumFeatureAggregatorTest2.cxx
+++ b/test/itkMinimumFeatureAggregatorTest2.cxx
@@ -39,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MinimumFeatureAggregatorSurrogate, MinimumFeatureAggregator);
+  itkOverrideGetNameOfClassMacro(MinimumFeatureAggregatorSurrogate);
 
   using InputFeatureType = Superclass::InputFeatureType;
 

--- a/test/itkSegmentationVolumeEstimatorTest1.cxx
+++ b/test/itkSegmentationVolumeEstimatorTest1.cxx
@@ -35,7 +35,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(VolumeEstimatorSurrogate, SegmentationVolumeEstimator);
+  itkOverrideGetNameOfClassMacro(VolumeEstimatorSurrogate);
 };
 
 } // namespace itk


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
