### PR TITLE
COMP: Rename test names that collide with ITK core tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,7 +161,7 @@ itk_add_test(NAME itkGradientMagnitudeSigmoidFeatureGeneratorTest1
   90.0
  )
 
-itk_add_test(NAME itkGradientMagnitudeImageFilterTest1
+itk_add_test(NAME LesionSizingToolkitGradientMagnitudeImageFilterTest1
   COMMAND ${ITK_TEST_DRIVER}
   $<TARGET_FILE:itkGradientMagnitudeImageFilter>
   ${TEST_DATA_ROOT}/Input/PartSolidLesionCropped.mha
@@ -216,7 +216,7 @@ itk_add_test(NAME itkCannyEdgeDetectionImageFilterTest1
   ${TEMP}/CannyEdgeDetectionNonMaximumSuppressionImageFilterTest1_1.mha
  )
 
-itk_add_test(NAME itkCannyEdgeDetectionImageFilterTest2
+itk_add_test(NAME LesionSizingToolkitCannyEdgeDetectionImageFilterTest2
   COMMAND ${ITK_TEST_DRIVER}
 --compare ${TEMP}/CannyEdgeDetectionImageFilterTest2_1.mha
           ${TEST_DATA_ROOT}/Baseline/CannyEdgeDetectionImageFilterTest2_1.mha


### PR DESCRIPTION
Rename the two test names that collide with ITK core tests, which ITK's nightly dashboards report as `AUTHOR_WARNING`s whenever this module is enabled.

Beyond the warning noise, duplicate test names share ITK's `Cleanup_<name>` fixture, so the colliding tests race under `ctest -j`.

<details>
<summary>The collision</summary>

`itk_add_test` keeps a global registry of test names (`CMake/ITKModuleTest.cmake`). Two names here are already registered by ITK core:

| Test name | ITK core owner |
|---|---|
| `itkGradientMagnitudeImageFilterTest1` | `Modules/Filtering/ImageGradient/test/CMakeLists.txt` |
| `itkCannyEdgeDetectionImageFilterTest2` | `Modules/Filtering/ImageFeature/test/CMakeLists.txt` |

ITK warns rather than fails for remote-module collisions, because they cannot be fixed in the ITK tree:

```cmake
# Duplicate names share the Cleanup_<name> fixture and race under ctest -j.
# Remote modules live in separate repositories, so a collision they cause
# cannot be fixed in this tree; warn instead of failing the configure.
```

Observed on the ITK nightly `Linux-Ubuntu-GCC-Doxygen` (blaster.kitware), https://open.cdash.org/builds/11424939/configure — 2 warnings, both from this module. No other module in that build produces any.

The module's other ~48 test names are unique and unchanged.

</details>

<details>
<summary>Verification</summary>

Full ITK configure with `-DModule_LesionSizingToolkit=ON`, same source tree and build directory for both runs:

| Configure | `Duplicate test name` warnings |
|---|---|
| ITK's currently pinned tag of this module | **2** (reproduces the dashboard exactly) |
| Same tree with this change applied | **0** |

Resulting ctest registrations — four distinct tests where there were two collisions:

```
#1792 itkCannyEdgeDetectionImageFilterTest2                        (ITK core)
#1933 itkGradientMagnitudeImageFilterTest1                         (ITK core)
#3722 LesionSizingToolkitGradientMagnitudeImageFilterTest1         (this module)
#3729 LesionSizingToolkitCannyEdgeDetectionImageFilterTest2        (this module)
```

Scope of the change: only the `NAME` argument of two `itk_add_test` calls. The executables, arguments, `--compare` baselines, and the `.mha` output filenames are untouched, and neither old name is referenced anywhere else in this repository.

</details>

Landing this does not by itself clear the dashboard warnings — ITK pins this module by commit in `Modules/Remote/LesionSizingToolkit.remote.cmake` (currently `affbf7b0958205e2aab388bf0c3b7b1d5b0089de`), so that pin needs bumping in a follow-up ITK change once this merges.

<!--
provenance: found 2026-07-18 auditing ITK nightly CDash configure output, build 11424939 (Linux-Ubuntu-GCC-Doxygen, blaster.kitware)
detection_site: ITK CMake/ITKModuleTest.cmake:130-134 (AUTHOR_WARNING for /Modules/Remote/ collisions)
real_cost: shared Cleanup_<name> fixture -> ctest -j race, not merely warning noise
verified: baseline 2 warnings at ITK-pinned tag -> 0 with this change; same ITK source tree and build dir
post_merge_action: bump GIT_TAG in ITK Modules/Remote/LesionSizingToolkit.remote.cmake from affbf7b0958205e2aab388bf0c3b7b1d5b0089de
-->
