### PR TITLE
COMP: Include itkImageRegionIteratorWithIndex.h where the type is used

### DIFF
--- a/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -23,6 +23,7 @@
 #include "itkNumericTraits.h"
 #include "itkProgressReporter.h"
 #include "itkGradientMagnitudeImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include <iostream>
 namespace itk
 {

--- a/test/itkRegionCompetitionImageFilterTest1.cxx
+++ b/test/itkRegionCompetitionImageFilterTest1.cxx
@@ -19,6 +19,7 @@ const
 #include "itkRegionCompetitionImageFilter.h"
 #include "itkImageFileWriter.h"
 #include "itkImage.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkTestingMacros.h"
 
 


### PR DESCRIPTION
Add the missing `#include "itkImageRegionIteratorWithIndex.h"` to the two files that use the type. Without it this module does not compile against current ITK main — 8 translation units fail.

<details>
<summary>Why it broke</summary>

Both files use `ImageRegionIteratorWithIndex` but never include its header, relying on it arriving transitively through another ITK header. Current ITK no longer provides it that way.

The two files fail differently because of how the name is spelled:

| File | Spelling | Compiler behaviour |
|---|---|---|
| `include/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx:411` | unqualified (inside `namespace itk`) | `error: use of undeclared identifier 'ImageRegionIteratorWithIndex'`, then cascading errors on `uit` |
| `test/itkRegionCompetitionImageFilterTest1.cxx:117` | `itk::`-qualified | `error: no template named 'ImageRegionIteratorWithIndex' in namespace 'itk'` — the compiler then recovers by substituting `ImageRegionConstIteratorWithIndex`, which rejects the later `itr.Set(...)` calls |

The second case is worth noting: the reported errors are `no member named 'Set' in 'itk::ImageRegionConstIteratorWithIndex<...>'`, which reads like a wrong-iterator-type bug. It is not — the declaration at line 117 already asks for the non-const iterator. It is the same missing include, seen through the compiler's error recovery.

These are the only two files in the module that use the type without including its header.

</details>

<details>
<summary>Verification</summary>

Built as an ITK remote module (`-DModule_LesionSizingToolkit=ON`), Release, AppleClang, arm64, macOS 26.5 SDK, against ITK `main` at `4213421`.

| Target | Before | After |
|---|---|---|
| `LesionSizingToolkitTestDriver` | 8 failing TUs | **0** |
| `LesionSizingToolkit-all` | 10 failing targets | **0**, exit 0 |

Failing translation units before the fix:

```
itkCannyEdgesDistanceAdvectionFieldFeatureGeneratorTest1.cxx
itkCannyEdgesDistanceFeatureGeneratorTest1.cxx
itkCannyEdgesFeatureGeneratorTest1.cxx
itkLesionSegmentationMethodTest4.cxx
itkLesionSegmentationMethodTest8.cxx
itkLesionSegmentationMethodTest8b.cxx
itkMinimumFeatureAggregatorTest1.cxx
itkRegionCompetitionImageFilterTest1.cxx
```

The breakage is not new to any recent change here — building the previously ITK-pinned commit (`affbf7b095…`) against the same ITK reproduces the identical 8 failures, so it has been latent since ITK stopped providing the header transitively.

Not covered: the test suite was not executed (requires the module's test data); this change is verified at compile/link only.

</details>

<!--
provenance: found 2026-07-18 while verifying an ITK-side bump of this module's pinned commit; the pin bump was blocked because the module does not build
root_cause: itkImageRegionIteratorWithIndex.h relied on transitive inclusion that current ITK main no longer provides
control_experiment: old pin affbf7b0958205e2aab388bf0c3b7b1d5b0089de and new pin 8a02cdb677248d8e05cdaf8183f0154ca7f6ea54 fail identically (same 8 TUs) -> pre-existing, not introduced by the test-name rename
masked_on_cdash: Doxygen nightly reports 0 build errors (never compiles the test driver); Favorite-Remotes nightly dies at configure before compiling
blocks: ITK Modules/Remote/LesionSizingToolkit.remote.cmake GIT_TAG bump from affbf7b095... — should point at a commit that both renames the tests and builds
gotcha: Module_LesionSizingToolkit_GIT_TAG is cached per build tree and shadows the .remote.cmake default; persistent dashboard trees will not pick up a new pin until that cache entry is cleared
-->
